### PR TITLE
Improve sorting defaults and fix directory counting in summary statistics

### DIFF
--- a/src/config/sorting.rs
+++ b/src/config/sorting.rs
@@ -41,7 +41,7 @@ pub struct SortingOptions {
 impl Default for SortingOptions {
     fn default() -> Self {
         Self {
-            sort_by: None,
+            sort_by: Some(SortKey::Name),
             reverse_sort: false,
             files_before_directories: true, // Default to traditional behavior
         }

--- a/src/core/formatter/markdown.rs
+++ b/src/core/formatter/markdown.rs
@@ -63,7 +63,13 @@ impl TreeFormatter for MarkdownFormatter {
                     NodeType::Symlink => { /* Not counted in summary */ }
                 }
             }
-            (dc, fc)
+            // Include root directory in count if it's a directory
+            let root_dir_increment = if config.input_source.root_is_directory {
+                1
+            } else {
+                0
+            };
+            (dc + root_dir_increment, fc)
         };
 
         writeln!(output)?;

--- a/src/core/formatter/text_tree.rs
+++ b/src/core/formatter/text_tree.rs
@@ -176,7 +176,13 @@ impl TreeFormatter for TextTreeFormatter {
                     NodeType::Symlink => { /* Symlinks are not explicitly counted in summary */ }
                 }
             }
-            (dc, fc)
+            // Include root directory in count if it's a directory
+            let root_dir_increment = if config.input_source.root_is_directory {
+                1
+            } else {
+                0
+            };
+            (dc + root_dir_increment, fc)
         };
         // FR8: Handling Empty Directories (covered by walker providing them)
 

--- a/src/core/sorter/comparators.rs
+++ b/src/core/sorter/comparators.rs
@@ -8,9 +8,12 @@ use crate::core::tree::builder::TempNode;
 use crate::core::tree::node::NodeType;
 use std::cmp::Ordering;
 
-/// Helper function to compare nodes by name.
+/// Helper function to compare nodes by name (case-insensitive).
 fn compare_by_name(a: &TempNode, b: &TempNode) -> Ordering {
-    a.node_info.name.cmp(&b.node_info.name)
+    a.node_info
+        .name
+        .to_lowercase()
+        .cmp(&b.node_info.name.to_lowercase())
 }
 
 /// Helper function to compare nodes by version.
@@ -26,7 +29,12 @@ fn compare_by_mtime(a: &TempNode, b: &TempNode) -> Ordering {
         (None, Some(_)) => Ordering::Greater, // None after valid MTime
         (None, None) => Ordering::Equal,   // Both None, fall through to name
     }
-    .then_with(|| a.node_info.name.cmp(&b.node_info.name))
+    .then_with(|| {
+        a.node_info
+            .name
+            .to_lowercase()
+            .cmp(&b.node_info.name.to_lowercase())
+    })
 }
 
 /// Helper function to compare nodes by change time.
@@ -37,7 +45,12 @@ fn compare_by_change_time(a: &TempNode, b: &TempNode) -> Ordering {
         (None, Some(_)) => Ordering::Greater, // None after valid change time
         (None, None) => Ordering::Equal,   // Both None, fall through to name
     }
-    .then_with(|| a.node_info.name.cmp(&b.node_info.name))
+    .then_with(|| {
+        a.node_info
+            .name
+            .to_lowercase()
+            .cmp(&b.node_info.name.to_lowercase())
+    })
 }
 
 /// Helper function to compare nodes by create time.
@@ -48,7 +61,12 @@ fn compare_by_create_time(a: &TempNode, b: &TempNode) -> Ordering {
         (None, Some(_)) => Ordering::Greater, // None after valid create time
         (None, None) => Ordering::Equal,   // Both None, fall through to name
     }
-    .then_with(|| a.node_info.name.cmp(&b.node_info.name))
+    .then_with(|| {
+        a.node_info
+            .name
+            .to_lowercase()
+            .cmp(&b.node_info.name.to_lowercase())
+    })
 }
 
 /// Helper function to compare nodes by word count.
@@ -59,7 +77,12 @@ fn compare_by_words(a: &TempNode, b: &TempNode) -> Ordering {
         (None, Some(_)) => Ordering::Greater,
         (None, None) => Ordering::Equal, // Both None (e.g. two dirs), fall through to name
     }
-    .then_with(|| a.node_info.name.cmp(&b.node_info.name))
+    .then_with(|| {
+        a.node_info
+            .name
+            .to_lowercase()
+            .cmp(&b.node_info.name.to_lowercase())
+    })
 }
 
 /// Helper function to compare nodes by line count.
@@ -70,7 +93,12 @@ fn compare_by_lines(a: &TempNode, b: &TempNode) -> Ordering {
         (None, Some(_)) => Ordering::Greater,
         (None, None) => Ordering::Equal,
     }
-    .then_with(|| a.node_info.name.cmp(&b.node_info.name))
+    .then_with(|| {
+        a.node_info
+            .name
+            .to_lowercase()
+            .cmp(&b.node_info.name.to_lowercase())
+    })
 }
 
 /// Helper function to compare nodes by custom function output.
@@ -88,7 +116,12 @@ fn compare_by_custom(a: &TempNode, b: &TempNode) -> Ordering {
         (None, Some(Err(_))) => Ordering::Greater,
         (None, None) => Ordering::Equal, // Both None, use name
     }
-    .then_with(|| a.node_info.name.cmp(&b.node_info.name))
+    .then_with(|| {
+        a.node_info
+            .name
+            .to_lowercase()
+            .cmp(&b.node_info.name.to_lowercase())
+    })
 }
 
 /// Core comparison logic that both comparison functions can use.
@@ -176,9 +209,12 @@ fn compare_by_size(a: &TempNode, b: &TempNode, files_before_directories: bool) -
             let size_b = b.node_info.size.unwrap_or(0);
 
             // Descending order: larger files first
-            size_b
-                .cmp(&size_a)
-                .then_with(|| a.node_info.name.cmp(&b.node_info.name))
+            size_b.cmp(&size_a).then_with(|| {
+                a.node_info
+                    .name
+                    .to_lowercase()
+                    .cmp(&b.node_info.name.to_lowercase())
+            })
         }
         (NodeType::Directory, NodeType::Directory) => {
             // For directories: compare by size if available (descending), then by name
@@ -186,9 +222,12 @@ fn compare_by_size(a: &TempNode, b: &TempNode, files_before_directories: bool) -
             let size_b = b.node_info.size.unwrap_or(0);
 
             // Descending order: larger directories first
-            size_b
-                .cmp(&size_a)
-                .then_with(|| a.node_info.name.cmp(&b.node_info.name))
+            size_b.cmp(&size_a).then_with(|| {
+                a.node_info
+                    .name
+                    .to_lowercase()
+                    .cmp(&b.node_info.name.to_lowercase())
+            })
         }
         _ => {
             // Mixed types when type bias is disabled
@@ -196,9 +235,12 @@ fn compare_by_size(a: &TempNode, b: &TempNode, files_before_directories: bool) -
             let size_b = b.node_info.size.unwrap_or(0);
 
             // Descending order: larger items first
-            size_b
-                .cmp(&size_a)
-                .then_with(|| a.node_info.name.cmp(&b.node_info.name))
+            size_b.cmp(&size_a).then_with(|| {
+                a.node_info
+                    .name
+                    .to_lowercase()
+                    .cmp(&b.node_info.name.to_lowercase())
+            })
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,8 @@
 
 // CLI module - WARNING: This is not part of the stable public API!
 // This module is only exposed publicly because the main binary needs access to it.
-// External library users should NOT depend on this module as it may change 
-// without notice in future versions. Use the public API functions like 
+// External library users should NOT depend on this module as it may change
+// without notice in future versions. Use the public API functions like
 // get_tree_nodes() and format_nodes() instead.
 #[doc(hidden)] // Hide from documentation
 pub mod cli;

--- a/tests/full_flow_tests.rs
+++ b/tests/full_flow_tests.rs
@@ -162,7 +162,7 @@ fn test_prune_empty_directories_flag_long() -> Result<()> {
     // Child Dirs: .hidden_dir_with_content, dir_with_content (2)
     // Child Files: .hidden_file.txt, file1.txt, root_file.txt (3)
     assert!(
-        output.trim_end().ends_with("2 directories, 3 files"),
+        output.trim_end().ends_with("3 directories, 3 files"),
         "Summary line mismatch. Output: {}",
         output
     );
@@ -200,7 +200,7 @@ fn test_prune_empty_directories_alias() -> Result<()> {
     assert!(!output.contains("parent_of_empty/"));
     assert!(!output.contains(".hidden_empty_dir/"));
     assert!(
-        output.trim_end().ends_with("2 directories, 3 files"),
+        output.trim_end().ends_with("3 directories, 3 files"),
         "Summary line mismatch. Output: {}",
         output
     );
@@ -256,7 +256,7 @@ fn test_pruning_disabled_shows_empty_dirs() -> Result<()> {
     // Dirs: .hidden_dir_with_content, .hidden_empty_dir, dir_with_content, empty_child, empty_dir1, parent_of_empty (6)
     // Files: .hidden_file.txt, file1.txt, root_file.txt (3)
     assert!(
-        output.trim_end().ends_with("6 directories, 3 files"),
+        output.trim_end().ends_with("7 directories, 3 files"),
         "Summary line mismatch. Output: {}",
         output
     );

--- a/tests/pruning_tests.rs
+++ b/tests/pruning_tests.rs
@@ -374,8 +374,8 @@ fn test_prune_output_format_consistency() -> Result<()> {
     // Formatter counts children for summary.
     // Nodes off: dir1 (d1), sub1 (d2), file1.txt (d2), dir2 (d1), root_file.txt (d1)
     // Dirs in nodes_off: dir1, sub1, dir2. Files: file1.txt, root_file.txt
-    // Summary: 3 directories, 2 files (these are children counts)
-    assert!(output_off.trim_end().ends_with("3 directories, 2 files"));
+    // Summary: 4 directories, 2 files (these are children counts)
+    assert!(output_off.trim_end().ends_with("4 directories, 2 files"));
 
     // With pruning ON: dir1, file1.txt, root_file.txt (sub1 and dir2 are pruned)
     assert!(output_on.contains("dir1/"));
@@ -393,7 +393,7 @@ fn test_prune_output_format_consistency() -> Result<()> {
     // Nodes on: dir1 (d1), file1.txt (d2), root_file.txt (d1)
     // Dirs in nodes_on: dir1. Files: file1.txt, root_file.txt
     // Summary: 1 directory, 2 files
-    assert!(output_on.trim_end().ends_with("1 directory, 2 files"));
+    assert!(output_on.trim_end().ends_with("2 directories, 2 files"));
 
     Ok(())
 }
@@ -418,12 +418,12 @@ fn test_prune_empty_root_directory_scenario() -> Result<()> {
     // The root itself is counted as 1 directory by the formatter if root_is_directory is true.
     // However, the PRD implies that if the root itself becomes empty, the output might be minimal.
     // The current `format_nodes` logic for summary counts nodes passed to it.
-    // If `nodes` is empty, it will report "0 directories, 0 files" for children.
+    // If `nodes` is empty, it will report "1 directory, 0 files" for children.
     // The root name is always printed.
     let expected_output = format!(
         r#"{}/
 
-0 directories, 0 files"#, // This reflects 0 child directories and 0 child files.
+1 directory, 0 files"#, // This reflects 0 child directories and 0 child files.
         root_name
     );
     assert_eq!(

--- a/tests/text_formatter_tests.rs
+++ b/tests/text_formatter_tests.rs
@@ -99,7 +99,7 @@ fn test_formatter_basic_structure() -> Result<()> {
     ├── empty_dir/
     └── file3.dat
 
-3 directories, 4 files"#,
+4 directories, 4 files"#,
         root_name
     );
 
@@ -318,7 +318,7 @@ fn test_formatter_with_max_depth() -> Result<()> {
 ├── file2.log
 └── sub_dir/
 
-1 directory, 2 files"#, // sub_dir is 1 dir, file1, file2 are 2 files
+2 directories, 2 files"#, // sub_dir is 1 dir, file1, file2 are 2 files
         root_name
     );
     assert_eq!(output_depth_1.trim(), expected_output_depth_1.trim());
@@ -353,7 +353,7 @@ fn test_formatter_with_max_depth() -> Result<()> {
     ├── empty_dir/
     └── file3.dat
 
-3 directories, 3 files"#, // sub_dir, another_sub_dir, empty_dir (3 dirs); file1, file2, file3 (3 files)
+4 directories, 3 files"#, // sub_dir, another_sub_dir, empty_dir (3 dirs); file1, file2, file3 (3 files)
         root_name
     );
     assert_eq!(output_depth_2.trim(), expected_output_depth_2.trim());
@@ -399,7 +399,7 @@ fn test_formatter_with_show_hidden() -> Result<()> {
     ├── empty_dir/
     └── file3.dat
 
-3 directories, 5 files"#,
+4 directories, 5 files"#,
         root_name
     );
     assert_eq!(output.trim(), expected_output.trim());
@@ -435,7 +435,7 @@ fn test_formatter_with_empty_directory() -> Result<()> {
     let expected_output = format!(
         r#"{}/
 
-0 directories, 0 files"#, // Expect a blank line before summary
+1 directory, 0 files"#, // Expect a blank line before summary
         root_name
     );
     assert_eq!(output.trim(), expected_output.trim());
@@ -495,7 +495,7 @@ fn test_formatter_with_show_size_bytes() -> Result<()> {
     ├── [     64B] empty_dir/
     └── [     15B] file3.dat
 
-3 directories, 3 files"#,
+4 directories, 3 files"#,
         root_name
     );
     assert_eq!(output.trim(), expected_output.trim());
@@ -542,7 +542,7 @@ fn test_formatter_with_show_last_modified() -> Result<()> {
 ├── {}file2.log
 └── {}sub_dir/
 
-1 directory, 2 files"#,
+2 directories, 2 files"#,
         root_name, mtime_file1, mtime_file2, mtime_subdir
     );
     assert_eq!(output.trim(), expected_output.trim());
@@ -589,7 +589,7 @@ fn test_formatter_with_calculate_lines() -> Result<()> {
     ├── empty_dir/
     └── [L:   2] file3.dat
 
-3 directories, 3 files"#,
+4 directories, 3 files"#,
         root_name
     );
     assert_eq!(output.trim(), expected_output.trim());
@@ -636,7 +636,7 @@ fn test_formatter_with_calculate_words() -> Result<()> {
     ├── empty_dir/
     └── [W:   2] file3.dat
 
-3 directories, 3 files"#,
+4 directories, 3 files"#,
         root_name
     );
     assert_eq!(output.trim(), expected_output.trim());
@@ -683,7 +683,7 @@ fn test_formatter_with_apply_function() -> Result<()> {
     ├── empty_dir/
     └── [F: "2"] file3.dat
 
-3 directories, 3 files"#,
+4 directories, 3 files"#,
         root_name
     );
     assert_eq!(output.trim(), expected_output.trim());
@@ -737,7 +737,7 @@ fn test_formatter_with_multiple_metadata() -> Result<()> {
 ├── [     12B] {}[L:   1] [W:   2] [F: "0"] file2.log
 └── [    192B] {}sub_dir/
 
-1 directory, 2 files"#,
+2 directories, 2 files"#,
         root_name, mtime_f1, mtime_f2, mtime_sd
     );
     assert_eq!(output.trim(), expected_output.trim());
@@ -773,8 +773,8 @@ fn test_formatter_summary_line() -> Result<()> {
     let nodes_basic = get_tree_nodes(root_path, &config_basic)?;
     let output_basic = format_nodes(&nodes_basic, LibOutputFormat::Text, &config_basic)?;
 
-    // From basic_structure: 3 directories, 4 files
-    assert!(output_basic.trim().ends_with("\n\n3 directories, 4 files"));
+    // From basic_structure: 4 directories, 4 files
+    assert!(output_basic.trim().ends_with("\n\n4 directories, 4 files"));
 
     let config_hidden = RustreeLibConfig {
         input_source: InputSourceOptions {
@@ -795,8 +795,8 @@ fn test_formatter_summary_line() -> Result<()> {
     };
     let nodes_hidden = get_tree_nodes(root_path, &config_hidden)?;
     let output_hidden = format_nodes(&nodes_hidden, LibOutputFormat::Text, &config_hidden)?;
-    // From show_hidden: 3 directories, 5 files
-    assert!(output_hidden.trim().ends_with("\n\n3 directories, 5 files"));
+    // From show_hidden: 4 directories, 5 files
+    assert!(output_hidden.trim().ends_with("\n\n4 directories, 5 files"));
 
     Ok(())
 }
@@ -845,7 +845,7 @@ fn test_formatter_sort_integration() -> Result<()> {
     ├── empty_dir/
     └── file3.dat
 
-3 directories, 3 files"#,
+4 directories, 3 files"#,
         root_name
     );
     assert_eq!(
@@ -893,7 +893,7 @@ fn test_formatter_sort_integration() -> Result<()> {
 ├── [     12B] file2.log
 └── [    192B] sub_dir/
 
-1 directory, 2 files"#,
+2 directories, 2 files"#,
         root_name
     );
     assert_eq!(


### PR DESCRIPTION
This PR addresses two key improvements to the tree output functionality:

###🔧 **Changes Made**

**1. Enhanced Sorting Behavior**
- Changed default sorting from `None` to `SortKey::Name` for consistent output
- Implemented case-insensitive sorting across all comparison functions (name, size, time-based sorts)
- Updated all comparator functions to use `to_lowercase()` for secondary name-based sorting

**2. Fixed Directory Count in Summary Statistics** 
- Root directory is now properly included in directory counts when `root_is_directory` is true
- Updated both text and markdown formatters to add root directory increment
- Fixed inconsistent summary statistics across different output formats

### 🧪 **Test Updates**
- Updated all test expectations to reflect corrected directory counts
- Tests now expect "4 directories" instead of "3 directories" in scenarios where root is counted
- Maintained test coverage for edge cases like empty directories

### 📊 **Impact**
- **Before**: Inconsistent sorting behavior and incorrect directory counts in summaries
- **After**: Predictable alphabetical sorting by default and accurate directory statistics

### 🔍 **Files Changed**
- `src/config/sorting.rs` - Updated default sort behavior
- `src/core/sorter/comparators.rs` - Case-insensitive sorting implementation  
- `src/core/formatter/` - Root directory counting fix for text and markdown formatters
- `tests/` - Updated test expectations to match corrected behavior

This change improves user experience by providing more intuitive default behavior and accurate file/directory statistics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Default sorting now organizes entries by name instead of leaving them unsorted.

- **Bug Fixes**
  - Directory counts in summary outputs now correctly include the root directory in both Markdown and text tree formats.
  - Sorting by name is now case-insensitive, ensuring consistent ordering regardless of letter casing.

- **Tests**
  - Updated test cases to reflect accurate directory counts and case-insensitive sorting behavior in summary outputs. 

- **Documentation**
  - Minor improvements to code comments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->