### PR TITLE
Add universal directory/file ordering options (--dirs-first, --files-first)

### DIFF
--- a/docs/src/architecture/modules.md
+++ b/docs/src/architecture/modules.md
@@ -26,7 +26,8 @@ This top-level module centralizes all configuration-related definitions for the 
 
 - **`sorting.rs`**:
   - Defines the `SortKey` enum (e.g., `Name`, `Size`, `MTime`, `Version`, `ChangeTime`, `CreateTime`, `None`).
-  - Defines `SortingOptions` struct, used in `RustreeLibConfig` to specify sorting criteria, order, and whether files should appear before directories in size-based sorts.
+  - Defines `DirectoryFileOrder` enum to control directory vs. file ordering (`Default`, `DirsFirst`, `FilesFirst`).
+  - Defines `SortingOptions` struct, used in `RustreeLibConfig` to specify sorting criteria, order, directory/file ordering preference, and backward compatibility options.
 
 - **`metadata.rs`**:
   - Defines `MetadataOptions` struct for metadata collection and content analysis flags (e.g., `show_size_bytes`, `show_last_modified`, `report_change_time`, `report_creation_time`).
@@ -73,7 +74,7 @@ The `src/core/` directory houses the main operational logic of `rustree`.
 
 - **`sorter/`**: This sub-module is responsible for sorting nodes while preserving the tree hierarchy.
   - `strategies.rs`: Contains `sort_nodes_with_options` (and the older `sort_nodes`), which orchestrates tree building, sorting of sibling nodes, and tree flattening.
-  - `comparators.rs`: Defines `compare_siblings_with_options` which implements the comparison logic for various `SortKey`s, considering `SortingOptions` like `reverse_sort` and `files_before_directories`. It includes improved version string comparison and new size sorting logic (defaulting to largest first, files before directories).
+  - `comparators.rs`: Defines `compare_siblings_with_options` which implements the comparison logic for various `SortKey`s, considering `SortingOptions` like `reverse_sort`, `files_before_directories` (legacy), and the new `directory_file_order` enum. It includes universal directory/file ordering that applies to all sort keys, improved version string comparison, and enhanced size sorting logic. The `apply_directory_file_ordering` function provides consistent directory vs. file ordering across all sorting modes.
   - `composite.rs`: (Placeholder for defining and using composite sort keys).
 
 - **`formatter/`**: This sub-module is responsible for generating the final output string.
@@ -90,8 +91,8 @@ The `src/core/` directory houses the main operational logic of `rustree`.
 ### Top-Level Library File (`src/lib.rs`)
 
 - Re-exports key public types from the `config` and `core` modules to form the library's public API. This includes:
-  - `RustreeLibConfig` and its constituent option structs: `InputSourceOptions`, `ListingOptions`, `FilteringOptions`, `SortingOptions` (including `files_before_directories`), `MetadataOptions`, `MiscOptions`.
-  - Enums and related types: `SortKey`, `BuiltInFunction`, `ApplyFnError`.
+  - `RustreeLibConfig` and its constituent option structs: `InputSourceOptions`, `ListingOptions`, `FilteringOptions`, `SortingOptions` (including `directory_file_order` and legacy `files_before_directories`), `MetadataOptions`, `MiscOptions`.
+  - Enums and related types: `SortKey`, `DirectoryFileOrder`, `BuiltInFunction`, `ApplyFnError`.
   - `LibOutputFormat` (an alias for `OutputFormat`).
 
 - Core types: `NodeInfo` (from `core::tree::node`), `NodeType`, and `RustreeError`.

--- a/docs/src/cli_usage/examples.md
+++ b/docs/src/cli_usage/examples.md
@@ -233,4 +233,41 @@ Here are some practical examples of how to use `rustree` from the command line.
     ```
     In this case, if a directory `src/utils/` contains only `helper.txt` and `mod.rs`, after `-P "*.rs"` is applied, `helper.txt` is filtered out. If `src/utils/` now only effectively contains `mod.rs`, it's not empty. However, if `src/empty_module/` contained only `old_code.txt`, it would first be filtered by `-P`, then `src/empty_module/` would become empty and subsequently pruned by `--prune`.
 
+29. **List directories before files for better readability:**
+
+    ```bash
+    rustree --dirs-first ./my_project
+    ```
+    This will show all directories before any files at each level, making the structure more readable by grouping similar types together.
+
+30. **List files before directories:**
+
+    ```bash
+    rustree --files-first ./my_project
+    ```
+    This will show all files before any directories at each level.
+
+31. **Combine directory ordering with different sort modes:**
+
+    ```bash
+    # Directories first, sorted by modification time
+    rustree --dirs-first --sort-by mtime ./my_project
+
+    # Files first, sorted by size (largest first)
+    rustree --files-first --sort-by size -r ./my_project
+
+    # Directories first with version sorting
+    rustree --dirs-first -v ./releases
+    ```
+
+32. **Directory ordering with metadata and filtering:**
+
+    ```bash
+    # Show directories first with sizes and modification times, only for .rs files and directories
+    rustree --dirs-first -s -D -P "*.rs|*/" ./src
+
+    # Files first, showing line counts for text files
+    rustree --files-first --calculate-lines -P "*.txt|*.md|*/" ./docs
+    ```
+
 Note: These examples cover common use cases. Combine options as needed to achieve your desired output! Remember to use `rustree --help` for a full list of options.

--- a/docs/src/cli_usage/options.md
+++ b/docs/src/cli_usage/options.md
@@ -132,13 +132,13 @@ If `PATH` is omitted, it defaults to the current directory (`.`).
   - Description: Reverse the order of the sort.
   - Example: `rustree -t -r` (newest mtime first), `rustree --sort-by size -r` (smallest size first)
 
-- `--files-first`
-  - Description: When sorting by size, list all files and symlinks before directories. This is the default behavior for size sort.
-  - Example: `rustree --sort-by size --files-first` (explicitly stating default)
+- `--dirs-first`
+  - Description: List directories before files. More readable. This applies to all sorting modes and overrides the default mixing behavior. Conflicts with `--files-first`.
+  - Example: `rustree --dirs-first`, `rustree --sort-by size --dirs-first`
 
-- `--no-files-first`
-  - Description: When sorting by size, intermingle files, symlinks, and directories based purely on their size.
-  - Example: `rustree --sort-by size --no-files-first`
+- `--files-first`
+  - Description: List files before directories. More readable. This applies to all sorting modes and overrides the default mixing behavior. Conflicts with `--dirs-first`.
+  - Example: `rustree --files-first`, `rustree --sort-by mtime --files-first`
 
 ## Output Formatting
 

--- a/src/cli/mapping.rs
+++ b/src/cli/mapping.rs
@@ -19,6 +19,7 @@ use crate::config::RustreeLibConfig;
 use crate::config::SortKey as LibSortKey;
 use crate::config::SortingOptions;
 use crate::config::output_format::OutputFormat as LibOutputFormat;
+use crate::config::sorting::DirectoryFileOrder;
 
 /// Maps command-line arguments (`CliArgs`) to the library's configuration structure (`RustreeLibConfig`).
 ///
@@ -104,6 +105,13 @@ pub fn map_cli_to_lib_config(cli_args: &CliArgs) -> RustreeLibConfig {
             },
             reverse_sort: cli_args.sort_order.reverse_sort,
             files_before_directories: true, // Default to traditional behavior
+            directory_file_order: if cli_args.sort_order.dirs_first {
+                DirectoryFileOrder::DirsFirst
+            } else if cli_args.sort_order.files_first {
+                DirectoryFileOrder::FilesFirst
+            } else {
+                DirectoryFileOrder::Default
+            },
         },
         metadata: MetadataOptions {
             show_size_bytes: cli_args.size.show_size_bytes,

--- a/src/cli/sorting/order.rs
+++ b/src/cli/sorting/order.rs
@@ -36,4 +36,14 @@ pub struct SortOrderArgs {
     /// Incompatible with -U/--unsorted.
     #[arg(short = 'r', long)]
     pub reverse_sort: bool,
+
+    /// List directories before files. More readable.
+    /// Conflicts with --files-first.
+    #[arg(long = "dirs-first", conflicts_with = "files_first")]
+    pub dirs_first: bool,
+
+    /// List files before directories. More readable.
+    /// Conflicts with --dirs-first.
+    #[arg(long = "files-first", conflicts_with = "dirs_first")]
+    pub files_first: bool,
 }

--- a/src/config/sorting.rs
+++ b/src/config/sorting.rs
@@ -1,3 +1,16 @@
+/// Defines the ordering preference for directories vs files.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DirectoryFileOrder {
+    /// Default behavior - ordering depends on the sort key.
+    /// For size sorting, files come before directories.
+    /// For other sort keys, files and directories are intermixed.
+    Default,
+    /// Directories are listed before files at each level.
+    DirsFirst,
+    /// Files (and symlinks) are listed before directories at each level.
+    FilesFirst,
+}
+
 /// Defines the keys by which directory entries can be sorted.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SortKey {
@@ -35,7 +48,10 @@ pub struct SortingOptions {
     /// Whether to sort files before directories when sorting by size.
     /// When true (default), files and symlinks appear before directories.
     /// When false, files and directories are intermixed based purely on size.
+    /// DEPRECATED: Use directory_file_order instead.
     pub files_before_directories: bool,
+    /// Determines the ordering of directories vs files.
+    pub directory_file_order: DirectoryFileOrder,
 }
 
 impl Default for SortingOptions {
@@ -44,6 +60,7 @@ impl Default for SortingOptions {
             sort_by: Some(SortKey::Name),
             reverse_sort: false,
             files_before_directories: true, // Default to traditional behavior
+            directory_file_order: DirectoryFileOrder::Default,
         }
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -134,3 +134,10 @@ pub mod common_test_utils {
             .into_owned()
     }
 }
+
+#[allow(dead_code)] // Used by CLI integration tests
+pub fn get_binary_path() -> String {
+    // Use the path to the built binary in target/debug/
+    let cargo_manifest_dir = env!("CARGO_MANIFEST_DIR");
+    format!("{}/target/debug/rustree", cargo_manifest_dir)
+}

--- a/tests/directory_ordering_tests.rs
+++ b/tests/directory_ordering_tests.rs
@@ -1,0 +1,408 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+mod common;
+
+/// Creates a test directory structure with both files and directories.
+/// Structure:
+/// temp_dir/
+/// ├── afile.txt
+/// ├── bdir/
+/// │   └── nested.txt
+/// ├── cfile.md  
+/// └── ddir/
+///     └── another.txt
+fn create_test_structure(temp_dir: &Path) -> std::io::Result<()> {
+    // Create files
+    fs::write(temp_dir.join("afile.txt"), "content1")?;
+    fs::write(temp_dir.join("cfile.md"), "content2")?;
+
+    // Create directories with files inside
+    fs::create_dir(temp_dir.join("bdir"))?;
+    fs::write(temp_dir.join("bdir").join("nested.txt"), "nested content")?;
+
+    fs::create_dir(temp_dir.join("ddir"))?;
+    fs::write(temp_dir.join("ddir").join("another.txt"), "another content")?;
+
+    Ok(())
+}
+
+#[test]
+fn test_dirs_first_flag() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    create_test_structure(temp_dir.path()).expect("Failed to create test structure");
+
+    let output = Command::new(common::get_binary_path())
+        .arg(temp_dir.path())
+        .arg("--dirs-first")
+        .arg("-L")
+        .arg("1")
+        .output()
+        .expect("Failed to execute rustree");
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+
+    // With --dirs-first, directories should appear before files
+    // Expected order: bdir/, ddir/, afile.txt, cfile.md
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // Find the relevant lines (skip the root directory line)
+    let mut content_lines = Vec::new();
+    for line in &lines {
+        if line.contains("bdir")
+            || line.contains("ddir")
+            || line.contains("afile.txt")
+            || line.contains("cfile.md")
+        {
+            content_lines.push(*line);
+        }
+    }
+
+    assert!(
+        content_lines.len() >= 4,
+        "Should have at least 4 content lines"
+    );
+
+    // Check that directories come before files
+    let mut dir_positions = Vec::new();
+    let mut file_positions = Vec::new();
+
+    for (i, line) in content_lines.iter().enumerate() {
+        if line.contains("bdir") || line.contains("ddir") {
+            dir_positions.push(i);
+        } else if line.contains("afile.txt") || line.contains("cfile.md") {
+            file_positions.push(i);
+        }
+    }
+
+    // All directories should come before all files
+    let max_dir_pos = dir_positions.iter().max().unwrap_or(&0);
+    let min_file_pos = file_positions.iter().min().unwrap_or(&999);
+
+    assert!(
+        max_dir_pos < min_file_pos,
+        "Directories should appear before files with --dirs-first. Max dir pos: {}, Min file pos: {}",
+        max_dir_pos,
+        min_file_pos
+    );
+}
+
+#[test]
+fn test_files_first_flag() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    create_test_structure(temp_dir.path()).expect("Failed to create test structure");
+
+    let output = Command::new(common::get_binary_path())
+        .arg(temp_dir.path())
+        .arg("--files-first")
+        .arg("-L")
+        .arg("1")
+        .output()
+        .expect("Failed to execute rustree");
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+
+    // With --files-first, files should appear before directories
+    // Expected order: afile.txt, cfile.md, bdir/, ddir/
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // Find the relevant lines (skip the root directory line)
+    let mut content_lines = Vec::new();
+    for line in &lines {
+        if line.contains("bdir")
+            || line.contains("ddir")
+            || line.contains("afile.txt")
+            || line.contains("cfile.md")
+        {
+            content_lines.push(*line);
+        }
+    }
+
+    assert!(
+        content_lines.len() >= 4,
+        "Should have at least 4 content lines"
+    );
+
+    // Check that files come before directories
+    let mut dir_positions = Vec::new();
+    let mut file_positions = Vec::new();
+
+    for (i, line) in content_lines.iter().enumerate() {
+        if line.contains("bdir") || line.contains("ddir") {
+            dir_positions.push(i);
+        } else if line.contains("afile.txt") || line.contains("cfile.md") {
+            file_positions.push(i);
+        }
+    }
+
+    // All files should come before all directories
+    let max_file_pos = file_positions.iter().max().unwrap_or(&0);
+    let min_dir_pos = dir_positions.iter().min().unwrap_or(&999);
+
+    assert!(
+        max_file_pos < min_dir_pos,
+        "Files should appear before directories with --files-first. Max file pos: {}, Min dir pos: {}",
+        max_file_pos,
+        min_dir_pos
+    );
+}
+
+#[test]
+fn test_default_ordering_mixed() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    create_test_structure(temp_dir.path()).expect("Failed to create test structure");
+
+    let output = Command::new(common::get_binary_path())
+        .arg(temp_dir.path())
+        .arg("-L")
+        .arg("1")
+        .output()
+        .expect("Failed to execute rustree");
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+
+    // With default ordering, items should be sorted alphabetically (mixed)
+    // Expected order: afile.txt, bdir/, cfile.md, ddir/
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    let mut content_lines = Vec::new();
+    for line in &lines {
+        if line.contains("bdir")
+            || line.contains("ddir")
+            || line.contains("afile.txt")
+            || line.contains("cfile.md")
+        {
+            content_lines.push(*line);
+        }
+    }
+
+    // Should have mixed ordering (not all dirs first, not all files first)
+    let mut has_file_before_dir = false;
+    let mut has_dir_before_file = false;
+
+    for i in 0..content_lines.len() - 1 {
+        let current_is_dir = content_lines[i].contains("dir");
+        let next_is_dir = content_lines[i + 1].contains("dir");
+
+        if !current_is_dir && next_is_dir {
+            has_file_before_dir = true;
+        }
+        if current_is_dir && !next_is_dir {
+            has_dir_before_file = true;
+        }
+    }
+
+    // In default mode with alphabetical ordering, we should have mixed ordering
+    assert!(
+        has_file_before_dir || has_dir_before_file,
+        "Default ordering should be mixed (alphabetical), not grouped by type"
+    );
+}
+
+#[test]
+fn test_flags_conflict() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    create_test_structure(temp_dir.path()).expect("Failed to create test structure");
+
+    let output = Command::new(common::get_binary_path())
+        .arg(temp_dir.path())
+        .arg("--dirs-first")
+        .arg("--files-first")
+        .output()
+        .expect("Failed to execute rustree");
+
+    // Should fail with error about conflicting arguments
+    assert!(
+        !output.status.success(),
+        "Command should fail when both flags are provided"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(
+        stderr.contains("cannot be used with"),
+        "Error message should mention conflicting arguments"
+    );
+}
+
+#[test]
+fn test_dirs_first_with_different_sort_keys() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    create_test_structure(temp_dir.path()).expect("Failed to create test structure");
+
+    // Test with size sorting
+    let output = Command::new(common::get_binary_path())
+        .arg(temp_dir.path())
+        .arg("--dirs-first")
+        .arg("--sort-by")
+        .arg("size")
+        .arg("-L")
+        .arg("1")
+        .output()
+        .expect("Failed to execute rustree");
+
+    assert!(output.status.success(), "Command should succeed");
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+
+    // Even with size sorting, directories should still come first
+    let lines: Vec<&str> = stdout.lines().collect();
+    let mut content_lines = Vec::new();
+    for line in &lines {
+        if line.contains("bdir")
+            || line.contains("ddir")
+            || line.contains("afile.txt")
+            || line.contains("cfile.md")
+        {
+            content_lines.push(*line);
+        }
+    }
+
+    let mut dir_positions = Vec::new();
+    let mut file_positions = Vec::new();
+
+    for (i, line) in content_lines.iter().enumerate() {
+        if line.contains("bdir") || line.contains("ddir") {
+            dir_positions.push(i);
+        } else if line.contains("afile.txt") || line.contains("cfile.md") {
+            file_positions.push(i);
+        }
+    }
+
+    if !dir_positions.is_empty() && !file_positions.is_empty() {
+        let max_dir_pos = dir_positions.iter().max().unwrap();
+        let min_file_pos = file_positions.iter().min().unwrap();
+
+        assert!(
+            max_dir_pos < min_file_pos,
+            "Directories should come before files even with size sorting"
+        );
+    }
+}
+
+#[test]
+fn test_files_first_with_reverse_sort() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    create_test_structure(temp_dir.path()).expect("Failed to create test structure");
+
+    let output = Command::new(common::get_binary_path())
+        .arg(temp_dir.path())
+        .arg("--files-first")
+        .arg("--reverse-sort")
+        .arg("-L")
+        .arg("1")
+        .output()
+        .expect("Failed to execute rustree");
+
+    assert!(output.status.success(), "Command should succeed");
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+
+    // With --files-first and reverse sort, files should come before directories
+    // and within each group they should be reverse sorted
+    let lines: Vec<&str> = stdout.lines().collect();
+    let mut content_lines = Vec::new();
+    for line in &lines {
+        if line.contains("bdir")
+            || line.contains("ddir")
+            || line.contains("afile.txt")
+            || line.contains("cfile.md")
+        {
+            content_lines.push(*line);
+        }
+    }
+
+    // Find first directory and last file
+    let mut last_file_pos = None;
+    let mut first_dir_pos = None;
+
+    for (i, line) in content_lines.iter().enumerate() {
+        if line.contains("afile.txt") || line.contains("cfile.md") {
+            last_file_pos = Some(i);
+        } else if (line.contains("bdir") || line.contains("ddir")) && first_dir_pos.is_none() {
+            first_dir_pos = Some(i);
+        }
+    }
+
+    if let (Some(last_file), Some(first_dir)) = (last_file_pos, first_dir_pos) {
+        assert!(
+            last_file < first_dir,
+            "Files should still come before directories with --files-first and reverse sort"
+        );
+    }
+}
+
+#[test]
+fn test_directory_ordering_in_subdirectories() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+    // Create a more complex structure
+    fs::create_dir(temp_dir.path().join("parent")).unwrap();
+    fs::write(temp_dir.path().join("parent").join("zfile.txt"), "content").unwrap();
+    fs::create_dir(temp_dir.path().join("parent").join("asubdir")).unwrap();
+    fs::write(
+        temp_dir
+            .path()
+            .join("parent")
+            .join("asubdir")
+            .join("nested.txt"),
+        "nested",
+    )
+    .unwrap();
+    fs::write(temp_dir.path().join("parent").join("bfile.txt"), "content2").unwrap();
+
+    let output = Command::new(common::get_binary_path())
+        .arg(temp_dir.path())
+        .arg("--dirs-first")
+        .arg("-L")
+        .arg("2")
+        .output()
+        .expect("Failed to execute rustree");
+
+    assert!(output.status.success(), "Command should succeed");
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
+
+    // Check that directory ordering applies at all levels
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // Find lines in the parent directory
+    let mut parent_content = Vec::new();
+    let mut in_parent = false;
+
+    for line in &lines {
+        if line.contains("parent/") || line.contains("parent\\") {
+            in_parent = true;
+            continue;
+        }
+        if in_parent {
+            if line.contains("asubdir") || line.contains("bfile.txt") || line.contains("zfile.txt")
+            {
+                parent_content.push(*line);
+            }
+            // Stop when we reach another top-level item or end
+            if !line.starts_with("│")
+                && !line.starts_with("├")
+                && !line.starts_with("└")
+                && !line.trim().is_empty()
+            {
+                break;
+            }
+        }
+    }
+
+    // In the parent directory, asubdir/ should come before bfile.txt and zfile.txt
+    if parent_content.len() >= 2 {
+        let dir_found = parent_content
+            .iter()
+            .position(|line| line.contains("asubdir"));
+        let file_found = parent_content
+            .iter()
+            .position(|line| line.contains("file.txt"));
+
+        if let (Some(dir_pos), Some(file_pos)) = (dir_found, file_found) {
+            assert!(
+                dir_pos < file_pos,
+                "Directory should come before files in subdirectory too"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## PR Description
This PR introduces universal directory and file ordering capabilities that work consistently across all sorting modes.

### New Features
- **`--dirs-first`**: Lists all directories before files at each level, improving readability by grouping similar types
- **`--files-first`**: Lists all files before directories at each level
- **Universal ordering**: These options work with all sort keys (name, size, mtime, version, etc.), not just size sorting

### Key Changes
- Added `DirectoryFileOrder` enum with `Default`, `DirsFirst`, and `FilesFirst` variants
- Updated `SortingOptions` struct to include the new `directory_file_order` field
- Enhanced comparison logic in `comparators.rs` to apply directory/file ordering before sort key comparison
- Added CLI flags `--dirs-first` and `--files-first` with mutual exclusion
- Maintained backward compatibility with existing `files_before_directories` option

### Technical Implementation
- New `apply_directory_file_ordering()` function provides consistent type-based ordering
- Directory/file ordering is applied first, then regular sort key comparison for items of the same type
- The ordering preference is NOT affected by reverse sort (only the sort key comparison is reversed)
- When `sort_by` is `None`, directory ordering is skipped to preserve original order

### Documentation Updates
- Updated architecture documentation to reflect the new ordering system
- Added practical examples showing directory ordering with various sort modes
- Updated CLI options documentation with new flags

### Testing
- Comprehensive integration tests covering all ordering scenarios
- Unit tests for the new comparison logic
- Tests for interaction with reverse sorting and different sort keys
- Validation of conflict detection between `--dirs-first` and `--files-first`

This enhancement makes rustree output more readable by allowing users to group directories and files consistently, regardless of the chosen sort criteria.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new CLI flags: `--dirs-first` and `--files-first` for explicit control over directory and file ordering in listings.
  - Introduced more flexible directory/file ordering options that apply to all sorting modes.
- **Documentation**
  - Updated module and CLI documentation to describe new ordering options and flags, with new usage examples.
- **Bug Fixes**
  - Improved error handling for conflicting ordering flags.
- **Tests**
  - Added comprehensive tests to verify correct behavior of directory/file ordering and error handling for conflicting flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->