### PR TITLE
Add LLM request preview with --dry-run and --human-friendly flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ rustree --llm-ask "Brief analysis" --llm-temperature 0.3 --llm-max-tokens 500
 - `--llm-temperature <float>`: Response randomness (0.0-2.0)
 - `--llm-max-tokens <int>`: Maximum response length
 - `--llm-generate-env`: Generate .env template
+- `--dry-run`: Preview LLM request without sending (for debugging/rough cost estimation)
+- `--human-friendly`: Format dry-run output in readable markdown (requires --dry-run)
 
 ## Examples
 
@@ -126,9 +128,25 @@ rustree --llm-ask "What could be optimized for better performance?" \
 ```bash
 # Use with external LLM CLI
 rustree --llm-export "Suggest refactoring opportunities" | some-llm-tool
+```
+
+### Request Preview and Debugging
+```bash
+# Preview what would be sent to the LLM (no API call)
+rustree --llm-ask "What's this project about?" --dry-run
+
+# Human-readable markdown format for better readability
+rustree --llm-ask "Analyze the architecture" --dry-run --human-friendly
+
+# Perfect for cost estimation and debugging prompts
+rustree --llm-ask "Complex analysis question" --llm-max-tokens 2000 --dry-run
+
+# Note: Token estimates are rough approximations (4:1 char ratio)
+# Use for planning only - actual usage may vary by content/provider
 
 # Save for later analysis
 rustree --llm-export "Technical debt assessment" > analysis-prompt.txt
+```
 ```
 
 ## For Developers

--- a/docs/src/cli_usage/examples.md
+++ b/docs/src/cli_usage/examples.md
@@ -231,21 +231,47 @@ Here are some practical examples of how to use `rustree` from the command line.
       --include "*.md" --include "*.rs" --calculate-words
     ```
 
-21. **LLM workflow examples:**
+21. **LLM request preview and debugging:**
 
     ```bash
-    # Step 1: Export for review
-    rustree --llm-export "Initial analysis" > project-analysis.txt
+    # Preview what would be sent to the LLM (no API call, no cost)
+    rustree --llm-ask "What's the architecture of this project?" --dry-run
     
-    # Step 2: Direct analysis with specific focus
+    # Human-readable markdown format for better readability
+    rustree --llm-ask "Analyze the code organization" \
+      --dry-run --human-friendly
+    
+    # Cost estimation for complex queries
+    rustree --llm-ask "Detailed security analysis with recommendations" \
+      --llm-max-tokens 3000 --dry-run
+    
+    # Debug prompt structure before sending
+    rustree --llm-ask "Custom analysis question" \
+      --include "*.rs" --depth 3 --size --dry-run --human-friendly
+    
+    # Verify API configuration without making requests
+    rustree --llm-ask "Test question" --llm-provider anthropic \
+      --llm-model claude-3-haiku --dry-run
+    ```
+
+22. **LLM workflow examples:**
+
+    ```bash
+    # Step 1: Preview and refine your question
+    rustree --llm-ask "Initial analysis" --dry-run --human-friendly
+    
+    # Step 2: Export for review
+    rustree --llm-export "Refined analysis question" > project-analysis.txt
+    
+    # Step 3: Direct analysis with verified prompt
     rustree --llm-ask "Focus on error handling patterns" \
-      --include "*.rs" --grep-pattern "Result\|Error"
+      --include "*.rs" --llm-temperature 0.3
     
-    # Step 3: Compare with external tool
+    # Step 4: Compare with external tool
     rustree --llm-export "Compare with previous analysis" | your-llm-tool
     ```
 
-22. **List only Rust source files (`*.rs`):**
+23. **List only Rust source files (`*.rs`):**
 
     ```bash
     rustree --filter-include "*.rs" ./my_project
@@ -253,7 +279,7 @@ Here are some practical examples of how to use `rustree` from the command line.
     rustree -P "*.rs" ./my_project
     ```
 
-23. **List only Markdown (`*.md`) or text (`*.txt`) files:**
+24. **List only Markdown (`*.md`) or text (`*.txt`) files:**
 
     ```bash
     rustree --filter-include "*.md|*.txt" ./notes
@@ -261,7 +287,7 @@ Here are some practical examples of how to use `rustree` from the command line.
     rustree -P "*.md" -P "*.txt" ./notes
     ```
 
-24. **List only directories named `build` or `target`:**
+25. **List only directories named `build` or `target`:**
     (Note: `-P` or `--filter-include` matches files and directories. A trailing `/` makes it specific to directories.)
     ```bash
     rustree --filter-include "build/|target/" ./my_project
@@ -269,7 +295,7 @@ Here are some practical examples of how to use `rustree` from the command line.
     rustree -P "build/|target/" ./my_project
     ```
 
-25. **List all Markdown files, including hidden ones (e.g., in `.github/`):**
+26. **List all Markdown files, including hidden ones (e.g., in `.github/`):**
 
     ```bash
     rustree --include-hidden --filter-include "*.md"
@@ -277,7 +303,7 @@ Here are some practical examples of how to use `rustree` from the command line.
     rustree -a -P "*.md"
     ```
 
-26. **List files starting with `test_` followed by any single character and then `.py`:**
+27. **List files starting with `test_` followed by any single character and then `.py`:**
 
     ```bash
     rustree --filter-include "test_?.py" ./tests
@@ -285,7 +311,7 @@ Here are some practical examples of how to use `rustree` from the command line.
     rustree -P "test_?.py" ./tests
     ```
 
-27. **List all files within any subdirectory named `docs`:**
+28. **List all files within any subdirectory named `docs`:**
 
     ```bash
     rustree --filter-include "docs/**" ./project_root
@@ -293,7 +319,7 @@ Here are some practical examples of how to use `rustree` from the command line.
     rustree -P "docs/**" ./project_root
     ```
 
-28. **Ignore all `.log` files:**
+29. **Ignore all `.log` files:**
 
     ```bash
     rustree --filter-exclude "*.log" ./my_project

--- a/docs/src/cli_usage/options.md
+++ b/docs/src/cli_usage/options.md
@@ -231,3 +231,12 @@ If `PATH` is omitted, it defaults to the current directory (`.`).
 - `--llm-generate-env`
   - Description: Generate a sample `.env` file template with all supported API key variables.
   - Example: `rustree --llm-generate-env > .env`
+
+- `--dry-run`
+  - Description: Preview the LLM request without actually sending it. When used with `--llm-ask`, RusTree builds the full HTTP request that would be sent to the provider, displays it, and exits without making the API call. This is useful for debugging, cost estimation, and verifying the request structure before sending.
+  - **Token Estimation**: Shows approximate token counts using a 4:1 character-to-token ratio for prompts and max_tokens setting for completion. These are rough estimates for planning purposes only - actual token usage may vary significantly based on content type and provider tokenization.
+  - Example: `rustree --llm-ask "What is this project?" --dry-run`
+
+- `--human-friendly`
+  - Description: Format dry-run output in a human-friendly markdown format instead of the default plain text. This option requires `--dry-run` to be enabled. The markdown format provides better structure with organized sections for configuration, headers, messages, and JSON body.
+  - Example: `rustree --llm-ask "Analyze this project" --dry-run --human-friendly`

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -79,3 +79,60 @@ A: You can sort by apply function results using `--sort-by custom`. This sorts b
 - Use `--reverse-sort` to reverse the order
 
 For example: `rustree --apply-function dir-stats --sort-by custom -r` sorts directories by complexity (most files/subdirs first).
+
+**Q: What's the difference between `--dry-run` and normal LLM queries?**
+A: The `--dry-run` flag previews what would be sent to the LLM without actually making the API call:
+- Shows exactly what request would be sent (headers, body, endpoint)
+- Displays token estimation for cost planning
+- No API key required and no network traffic
+- Perfect for debugging prompts and verifying configurations
+- Can be combined with `--human-friendly` for better readability
+
+**Q: When should I use `--human-friendly` with `--dry-run`?**
+A: Use `--human-friendly` when you want easier-to-read output:
+- Organizes information into clear sections (Configuration, Headers, Messages, etc.)
+- Formats JSON in a more readable way
+- Shows key parameters prominently
+- Great for sharing dry-run outputs or documentation
+- Note: `--human-friendly` requires `--dry-run` to be enabled
+
+**Q: How do I estimate LLM costs before making requests?**
+A: Use `--dry-run` to see token estimates:
+```bash
+rustree --llm-ask "Your question" --dry-run
+# Shows: "Estimated tokens: 356 prompt + 1000 completion ≈ 1356 total"
+```
+Then calculate costs based on your provider's pricing (e.g., OpenAI charges per 1000 tokens).
+
+**Q: How accurate are the token estimates shown in `--dry-run`?**
+A: The token estimates are **rough approximations** using simple heuristics:
+
+**Estimation Method:**
+- **Prompt tokens**: Uses a 4:1 character-to-token ratio (`prompt_length / 4`)
+- **Completion tokens**: Uses your `--llm-max-tokens` setting (assumes full usage)
+- **Total**: Simple addition of prompt + completion estimates
+
+**Limitations & Accuracy:**
+- ⚠️ **This is a ballpark estimate, not precise billing calculation**
+- Character-to-token ratios vary significantly by content type:
+  - Code/structured text: Often more tokens per character
+  - Natural language: Closer to 4:1 ratio
+  - Special characters/punctuation: Affects ratio
+- Different providers use different tokenizers (OpenAI/tiktoken, Anthropic, Cohere)
+- Assumes maximum completion token usage (rarely happens in practice)
+- Doesn't account for JSON request overhead
+
+**Recommendations:**
+- Use estimates for rough cost planning and comparing prompt sizes
+- For precise billing, use provider-specific tokenization tools:
+  - OpenAI: `tiktoken` library
+  - Anthropic: Claude API token counting
+  - Check your provider's dashboard for actual usage
+- Consider estimates as "worst-case" scenarios for budgeting
+
+**Q: How are the `<tree_output>` and `<user_request>` tags used?**
+A: These XML-style tags help the LLM understand the prompt structure:
+- `<tree_output>...</tree_output>` contains the directory tree from the tree command
+- `<user_request>...</user_request>` contains your question/request
+- This clear separation helps LLMs provide more relevant and focused responses
+- The tags are automatically added to all LLM requests

--- a/docs/src/library_usage/concepts.md
+++ b/docs/src/library_usage/concepts.md
@@ -142,7 +142,10 @@ This function takes the nodes, a `LibOutputFormat` enum (`Text` or `Markdown`, f
 
 - **`SortKey`**: `Name`, `Version`, `Size`, `MTime`, `ChangeTime`, `CreateTime`, `Words`, `Lines`, `Custom`, `None`. Defined in `src/config/sorting.rs`. Used in `RustreeLibConfig.sorting.sort_by`.
 - **`LibOutputFormat`**: `Text`, `Markdown`. Defined in `src/config/output_format.rs` (as `OutputFormat`). Used with `format_nodes()`.
-- **`BuiltInFunction`**: `CountPluses` (counts '+' characters), `Cat` (returns full file content). Defined in `src/config/metadata.rs`. Used in `RustreeLibConfig.metadata.apply_function`. When using `Cat`, the `format_nodes()` function automatically displays file contents after the tree structure.
+- **`BuiltInFunction`**: 
+  - File functions: `CountPluses` (counts '+' characters), `Cat` (returns full file content)
+  - Directory functions: `CountFiles`, `CountDirectories`, `SizeTotal`, `DirStats`
+  - Defined in `src/config/metadata.rs`. Used in `RustreeLibConfig.metadata.apply_function`. When using `Cat`, the `format_nodes()` function automatically displays file contents after the tree structure.
 - **`ApplyFnError`**: Error type for `BuiltInFunction` application. Defined in `src/config/metadata.rs`.
 - **`NodeType`**: `File`, `Directory`, `Symlink`. Defined in `src/core/tree/node.rs`. Found in `NodeInfo`.
 - **`RustreeError`**: The error type returned by library functions. Defined in `src/core/error.rs`. Includes variants like `Io`, `GlobPattern`, `IgnoreError`, and `TreeBuildError` (for errors during internal tree construction or sorting).

--- a/src/cli/llm.rs
+++ b/src/cli/llm.rs
@@ -80,4 +80,17 @@ pub struct LlmArgs {
     /// Generate a sample .env file template for LLM API keys
     #[arg(long)]
     pub llm_generate_env: bool,
+
+    /// Preview the LLM request without actually sending it.
+    ///
+    /// When used together with `--llm-ask`, RusTree will build the full HTTP
+    /// request that would be sent to the provider, print it to stdout, and
+    /// exit without incurring any API cost. Supplying `--dry-run` without
+    /// `--llm-ask` has no effect other than a short notice.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Format dry-run output in a human-friendly markdown format
+    #[arg(long, requires = "dry_run")]
+    pub human_friendly: bool,
 }

--- a/src/core/llm/mod.rs
+++ b/src/core/llm/mod.rs
@@ -45,12 +45,14 @@
 
 pub mod client;
 pub mod error;
+pub mod preview;
 pub mod prompt;
 pub mod providers;
 pub mod response;
 
 pub use client::LlmClientFactory;
 pub use error::LlmError;
+pub use preview::RequestPreview;
 pub use prompt::TreePromptFormatter;
 pub use providers::{LlmConfig, LlmProvider};
 pub use response::LlmResponseProcessor;

--- a/src/core/llm/preview.rs
+++ b/src/core/llm/preview.rs
@@ -1,0 +1,295 @@
+//! LLM Request Preview (Dry-Run)
+//!
+//! This module builds a representation of the HTTP request that would be sent
+//! to an LLM provider, allowing users to inspect it when the `--dry-run` flag
+//! is supplied.  The goal is **zero network traffic** while re-using the same
+//! configuration values used for the real call.
+
+use super::providers::LlmConfig;
+use serde_json::json;
+
+/// A human-readable preview of the outgoing LLM request.
+#[derive(Debug, Clone)]
+pub struct RequestPreview {
+    pub provider: String,
+    pub endpoint: String,
+    pub model: String,
+    pub temperature: f32,
+    pub max_tokens: u32,
+    pub headers: Vec<(String, String)>,
+    pub body: serde_json::Value,
+    pub estimated_prompt_tokens: Option<u32>,
+    pub estimated_completion_tokens: Option<u32>,
+}
+
+impl RequestPreview {
+    /// Build a preview from an [`LlmConfig`] and the prompt text.
+    pub fn from_config(cfg: &LlmConfig, prompt: &str) -> Self {
+        // Rough heuristic: 1 token ≈ 4 characters. Guard against zero length.
+        let prompt_tokens = ((prompt.len() as f32) / 4.0).ceil() as u32;
+
+        // Determine endpoint based on provider / cfg.endpoint
+        let endpoint = match cfg.provider {
+            super::providers::LlmProvider::OpenAi => cfg
+                .endpoint
+                .clone()
+                .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+            super::providers::LlmProvider::Anthropic => cfg
+                .endpoint
+                .clone()
+                .unwrap_or_else(|| "https://api.anthropic.com/v1".to_string()),
+            super::providers::LlmProvider::Cohere => cfg
+                .endpoint
+                .clone()
+                .unwrap_or_else(|| "https://api.cohere.ai/v1".to_string()),
+            super::providers::LlmProvider::OpenRouter => cfg
+                .endpoint
+                .clone()
+                .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
+        };
+
+        // Build provider-specific request body to match actual wire format
+        let body = match cfg.provider {
+            super::providers::LlmProvider::OpenAi | super::providers::LlmProvider::OpenRouter => {
+                json!({
+                    "model": cfg.model,
+                    "messages": [ { "role": "user", "content": prompt } ],
+                    "temperature": cfg.temperature,
+                    "max_tokens": cfg.max_tokens
+                })
+            }
+            super::providers::LlmProvider::Anthropic => {
+                json!({
+                    "model": cfg.model,
+                    "max_tokens": cfg.max_tokens,
+                    "messages": [ { "role": "user", "content": prompt } ],
+                    "temperature": cfg.temperature
+                })
+            }
+            super::providers::LlmProvider::Cohere => {
+                json!({
+                    "model": cfg.model,
+                    "message": prompt,
+                    "temperature": cfg.temperature,
+                    "max_tokens": cfg.max_tokens
+                })
+            }
+        };
+
+        let masked_key = mask_key(&cfg.api_key);
+
+        // Build provider-specific headers
+        let headers = match cfg.provider {
+            super::providers::LlmProvider::OpenAi | super::providers::LlmProvider::OpenRouter => {
+                vec![
+                    (
+                        "Authorization".to_string(),
+                        format!("Bearer {}", masked_key),
+                    ),
+                    ("Content-Type".to_string(), "application/json".to_string()),
+                ]
+            }
+            super::providers::LlmProvider::Anthropic => {
+                vec![
+                    ("x-api-key".to_string(), masked_key),
+                    ("Content-Type".to_string(), "application/json".to_string()),
+                    ("anthropic-version".to_string(), "2023-06-01".to_string()),
+                ]
+            }
+            super::providers::LlmProvider::Cohere => {
+                vec![
+                    (
+                        "Authorization".to_string(),
+                        format!("Bearer {}", masked_key),
+                    ),
+                    ("Content-Type".to_string(), "application/json".to_string()),
+                ]
+            }
+        };
+
+        RequestPreview {
+            provider: cfg.provider.name().to_string(),
+            endpoint,
+            model: cfg.model.clone(),
+            temperature: cfg.temperature,
+            max_tokens: cfg.max_tokens,
+            headers,
+            body,
+            estimated_prompt_tokens: Some(prompt_tokens),
+            estimated_completion_tokens: Some(cfg.max_tokens),
+        }
+    }
+
+    /// Render the preview as a colourful, human-friendly text block.
+    pub fn pretty_print(&self) -> String {
+        self.format_output(false)
+    }
+
+    /// Render the preview in markdown format for better readability.
+    pub fn pretty_print_markdown(&self) -> String {
+        self.format_output(true)
+    }
+
+    /// Internal method to format output in either plain text or markdown.
+    fn format_output(&self, markdown: bool) -> String {
+        use std::fmt::Write as _;
+
+        let mut out = String::new();
+
+        if markdown {
+            writeln!(out, "# LLM Request Preview (dry-run)").ok();
+            writeln!(out).ok();
+            writeln!(out, "## Configuration").ok();
+            writeln!(out).ok();
+            writeln!(out, "| Parameter | Value |").ok();
+            writeln!(out, "|-----------|-------|").ok();
+            writeln!(out, "| Provider | {} |", self.provider).ok();
+            writeln!(out, "| Endpoint | `{}` |", self.endpoint).ok();
+            writeln!(out, "| Model | {} |", self.model).ok();
+            writeln!(out, "| Temperature | {} |", self.temperature).ok();
+            writeln!(out, "| Max tokens | {} |", self.max_tokens).ok();
+            writeln!(out).ok();
+
+            writeln!(out, "## Headers").ok();
+            writeln!(out).ok();
+            writeln!(out, "```").ok();
+            for (k, v) in &self.headers {
+                writeln!(out, "{}: {}", k, v).ok();
+            }
+            writeln!(out, "```").ok();
+            writeln!(out).ok();
+
+            writeln!(out, "## Request Body").ok();
+            writeln!(out).ok();
+
+            // Extract and format key fields for better readability
+            if let Some(model) = self.body.get("model").and_then(|v| v.as_str()) {
+                writeln!(out, "**Model**: `{}`", model).ok();
+                writeln!(out).ok();
+            }
+
+            if let Some(temp) = self.body.get("temperature").and_then(|v| v.as_f64()) {
+                writeln!(out, "**Temperature**: {:.2}", temp).ok();
+                writeln!(out).ok();
+            }
+
+            if let Some(max_tokens) = self.body.get("max_tokens").and_then(|v| v.as_u64()) {
+                writeln!(out, "**Max Tokens**: {}", max_tokens).ok();
+                writeln!(out).ok();
+            }
+
+            // Format messages section
+            if let Some(messages) = self.body.get("messages").and_then(|v| v.as_array()) {
+                writeln!(out, "### Messages").ok();
+                writeln!(out).ok();
+
+                for (i, msg) in messages.iter().enumerate() {
+                    if let (Some(role), Some(content)) = (
+                        msg.get("role").and_then(|v| v.as_str()),
+                        msg.get("content").and_then(|v| v.as_str()),
+                    ) {
+                        writeln!(out, "**Message {} ({})**:", i + 1, role).ok();
+                        writeln!(out).ok();
+                        writeln!(out, "```").ok();
+                        writeln!(out, "{}", content).ok();
+                        writeln!(out, "```").ok();
+                        writeln!(out).ok();
+                    }
+                }
+            }
+
+            // Include full JSON request
+            writeln!(out, "### Full JSON Request").ok();
+            writeln!(out).ok();
+            writeln!(out, "```json").ok();
+            let body_pretty = serde_json::to_string_pretty(&self.body).unwrap_or_default();
+            write!(out, "{}", body_pretty).ok();
+            writeln!(out, "\n```").ok();
+
+            if let Some(prompt_tk) = self.estimated_prompt_tokens {
+                let comp_tk = self.estimated_completion_tokens.unwrap_or(0);
+                let total = prompt_tk + comp_tk;
+                writeln!(out).ok();
+                writeln!(out, "## Token Estimation").ok();
+                writeln!(out).ok();
+                writeln!(out, "- **Prompt tokens**: {}", prompt_tk).ok();
+                writeln!(out, "- **Completion tokens**: {}", comp_tk).ok();
+                writeln!(out, "- **Total tokens**: ≈ {}", total).ok();
+            }
+        } else {
+            writeln!(out, "─── LLM REQUEST PREVIEW (dry-run) ───").ok();
+            writeln!(out, "Provider        : {}", self.provider).ok();
+            writeln!(out, "Endpoint        : {}", self.endpoint).ok();
+            writeln!(out, "Model           : {}", self.model).ok();
+            writeln!(out, "Temperature     : {}", self.temperature).ok();
+            writeln!(out, "Max tokens      : {}", self.max_tokens).ok();
+
+            writeln!(out, "\nHeaders:").ok();
+            for (k, v) in &self.headers {
+                writeln!(out, "  {}: {}", k, v).ok();
+            }
+
+            writeln!(out, "\nBody:").ok();
+            let body_pretty = serde_json::to_string_pretty(&self.body).unwrap_or_default();
+            for line in body_pretty.lines() {
+                writeln!(out, "  {}", line).ok();
+            }
+
+            if let Some(prompt_tk) = self.estimated_prompt_tokens {
+                let comp_tk = self.estimated_completion_tokens.unwrap_or(0);
+                let total = prompt_tk + comp_tk;
+                writeln!(
+                    out,
+                    "\nEstimated tokens: {} prompt + {} completion ≈ {} total",
+                    prompt_tk, comp_tk, total
+                )
+                .ok();
+            }
+
+            writeln!(out, "──────────────────────────────────────").ok();
+        }
+
+        out
+    }
+}
+
+/// Mask all but first and last 2 chars of the key for display.
+fn mask_key(key: &str) -> String {
+    if key.len() <= 4 {
+        return "****".to_string();
+    }
+    let (first, last) = key.split_at(2);
+    let last2 = &last[last.len().saturating_sub(2)..];
+    format!("{}{}{}", first, "*".repeat(8), last2)
+}
+
+// Unit tests for preview
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::llm::providers::{LlmConfig, LlmProvider};
+    use std::time::Duration;
+
+    fn dummy_cfg() -> LlmConfig {
+        LlmConfig {
+            provider: LlmProvider::OpenAi,
+            model: "gpt-4".to_string(),
+            api_key: "sk-test123456".to_string(),
+            endpoint: None,
+            temperature: 0.5,
+            max_tokens: 100,
+            timeout: Duration::from_secs(30),
+        }
+    }
+
+    #[test]
+    fn preview_contains_prompt() {
+        let cfg = dummy_cfg();
+        let prompt = "Hello world";
+        let preview = RequestPreview::from_config(&cfg, prompt);
+        let printed = preview.pretty_print();
+        assert!(printed.contains("Hello world"));
+        assert!(printed.contains("gpt-4"));
+        assert!(printed.contains("openai"));
+    }
+}

--- a/src/core/llm/prompt.rs
+++ b/src/core/llm/prompt.rs
@@ -13,13 +13,10 @@ impl TreePromptFormatter {
         let metadata_info = Self::extract_metadata_info(tree_output, tree_config);
 
         format!(
-            "You are analyzing a directory tree structure. Here's the tree output:\n\n\
-            ```\n{}\n```\n\n\
+            "You are analyzing a directory tree structure.\n\n\
+            <tree_output>\n{}\n</tree_output>\n\n\
             {}\
-            Question: {}\n\n\
-            Please provide a helpful analysis based on the directory structure above. \
-            Focus on architectural patterns, code organization, potential issues, \
-            and actionable insights.",
+            <user_request>{}</user_request>",
             tree_output, metadata_info, user_question
         )
     }

--- a/tests/llm_cli_integration_tests.rs
+++ b/tests/llm_cli_integration_tests.rs
@@ -15,6 +15,8 @@ fn test_llm_args_default() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     // Test that defaults are sensible
@@ -36,6 +38,8 @@ fn test_llm_options_from_export_args() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let options = LlmOptions::from_cli_args(&args);
@@ -57,6 +61,8 @@ fn test_llm_options_from_ask_args() {
         llm_temperature: Some(0.5),
         llm_max_tokens: Some(1500),
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let options = LlmOptions::from_cli_args(&args);
@@ -78,6 +84,8 @@ fn test_llm_options_from_both_args() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let options = LlmOptions::from_cli_args(&args);
@@ -100,6 +108,8 @@ fn test_llm_options_from_empty_args() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let options = LlmOptions::from_cli_args(&args);
@@ -130,6 +140,8 @@ fn test_generate_env_flag() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: true,
+        dry_run: false,
+        human_friendly: false,
     };
 
     assert!(args.llm_generate_env);
@@ -151,6 +163,8 @@ fn test_complex_args_configuration() {
         llm_temperature: Some(0.2),
         llm_max_tokens: Some(2000),
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     // All fields should be preserved
@@ -186,6 +200,8 @@ fn test_edge_case_empty_strings() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let options = LlmOptions::from_cli_args(&args);
@@ -208,6 +224,8 @@ fn test_boundary_values() {
         llm_temperature: Some(0.0), // Minimum temperature
         llm_max_tokens: Some(1),    // Minimum tokens
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     assert_eq!(args.llm_temperature.unwrap(), 0.0);
@@ -226,6 +244,8 @@ fn test_maximum_boundary_values() {
         llm_temperature: Some(2.0),  // Maximum temperature
         llm_max_tokens: Some(32000), // Maximum tokens (for our validation)
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     assert_eq!(args.llm_temperature.unwrap(), 2.0);
@@ -245,6 +265,8 @@ fn test_debug_implementation() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let debug_string = format!("{:?}", args);
@@ -282,6 +304,8 @@ fn test_provider_case_handling() {
             llm_temperature: None,
             llm_max_tokens: None,
             llm_generate_env: false,
+            dry_run: false,
+            human_friendly: false,
         };
 
         // Should not panic when creating LlmOptions

--- a/tests/llm_env_tests.rs
+++ b/tests/llm_env_tests.rs
@@ -29,6 +29,8 @@ fn test_env_variable_loading() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let config = LlmConfig::from_cli_args(&llm_args).expect("Should create config from env var");
@@ -59,6 +61,8 @@ fn test_cli_key_overrides_env() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let config = LlmConfig::from_cli_args(&llm_args).expect("Should create config with CLI key");
@@ -88,6 +92,8 @@ fn test_missing_api_key_error() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let result = LlmConfig::from_cli_args(&llm_args);

--- a/tests/llm_prompt_tests.rs
+++ b/tests/llm_prompt_tests.rs
@@ -15,8 +15,11 @@ fn test_basic_prompt_formatting() {
     assert!(prompt.contains("You are analyzing a directory tree structure"));
     assert!(prompt.contains(tree_output));
     assert!(prompt.contains(question));
-    assert!(prompt.contains("architectural patterns"));
-    assert!(prompt.contains("actionable insights"));
+    // Check for XML tags in new structure
+    assert!(prompt.contains("<tree_output>"));
+    assert!(prompt.contains("</tree_output>"));
+    assert!(prompt.contains("<user_request>"));
+    assert!(prompt.contains("</user_request>"));
 }
 
 #[test]
@@ -158,7 +161,8 @@ fn test_empty_inputs() {
 
     // Should handle empty inputs gracefully
     assert!(prompt.contains("You are analyzing"));
-    assert!(prompt.contains("Question:"));
+    assert!(prompt.contains("<user_request>"));
+    assert!(prompt.contains("</user_request>"));
     // Should not crash or panic
 }
 
@@ -194,9 +198,9 @@ fn test_prompt_structure() {
     // Should start with the system instruction
     assert!(lines[0].contains("You are analyzing"));
 
-    // Should have code block markers
-    assert!(prompt.contains("```"));
-
-    // Should end with guidance
-    assert!(prompt.contains("Focus on architectural patterns"));
+    // Should have XML tag structure
+    assert!(prompt.contains("<tree_output>"));
+    assert!(prompt.contains("</tree_output>"));
+    assert!(prompt.contains("<user_request>"));
+    assert!(prompt.contains("</user_request>"));
 }

--- a/tests/llm_provider_tests.rs
+++ b/tests/llm_provider_tests.rs
@@ -88,6 +88,8 @@ fn test_config_with_custom_model() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let config = LlmConfig::from_cli_args(&args).expect("Should create config");
@@ -116,6 +118,8 @@ fn test_config_validation_temperature() {
         llm_temperature: Some(1.5),
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let config = LlmConfig::from_cli_args(&args).expect("Should create config");
@@ -170,6 +174,8 @@ fn test_config_validation_max_tokens() {
         llm_temperature: None,
         llm_max_tokens: Some(500),
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let config = LlmConfig::from_cli_args(&args).expect("Should create config");
@@ -223,6 +229,8 @@ fn test_config_defaults() {
         llm_temperature: None,
         llm_max_tokens: None,
         llm_generate_env: false,
+        dry_run: false,
+        human_friendly: false,
     };
 
     let config = LlmConfig::from_cli_args(&args).expect("Should create config");
@@ -268,6 +276,8 @@ impl LlmArgsBuilder {
                 llm_temperature: None,
                 llm_max_tokens: None,
                 llm_generate_env: false,
+                dry_run: false,
+                human_friendly: false,
             },
         }
     }


### PR DESCRIPTION
## PR Description

Adds dry-run functionality for LLM requests, allowing users to preview what would be sent to the API without making actual network calls or incurring costs.

### New Features

- **`--dry-run` flag**: Preview LLM requests without sending them
  - Shows exact HTTP request structure (headers, body, endpoint)
  - Displays token estimation for cost planning
  - No API key required and zero network traffic
  - Perfect for debugging prompts and verifying configurations

- **`--human-friendly` flag**: Enhanced dry-run output formatting
  - Organizes information into clear markdown sections
  - Shows configuration, headers, messages, and JSON body separately
  - Improves readability for sharing and documentation
  - Requires `--dry-run` to be enabled

### Improvements

- **Enhanced prompt structure**: Uses XML-style tags (`<tree_output>` and `<user_request>`) for better LLM comprehension
- **Comprehensive documentation**: Updated CLI usage examples, options reference, and FAQ
- **Better error handling**: Graceful handling of dry-run without LLM ask
- **Token estimation**: Rough cost estimation using 4-character-per-token heuristic

### Usage Examples

```bash
# Preview basic request
rustree --llm-ask "What's this project about?" --dry-run

# Human-readable markdown format
rustree --llm-ask "Analyze the architecture" --dry-run --human-friendly

# Cost estimation for complex queries
rustree --llm-ask "Detailed analysis" --llm-max-tokens 3000 --dry-run
```

### Technical Details

- New `preview.rs` module handles request preview generation
- Reuses existing configuration logic for consistency
- Supports all LLM providers (OpenAI, Anthropic, Cohere, OpenRouter)
- API key masking for security in output
- Comprehensive test coverage for new functionality

This enhancement significantly improves the developer experience by providing visibility into LLM requests before execution, enabling better prompt engineering and cost management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--dry-run` option to preview LLM requests and estimate token usage without sending data or requiring an API key.
  - Added `--human-friendly` option to display dry-run output in a readable markdown format.

- **Documentation**
  - Updated user guides, FAQ, and examples to explain and demonstrate the new LLM preview and formatting options.
  - Clarified the use of XML-style tags in LLM prompts for improved structure and readability.

- **Bug Fixes**
  - Suppressed empty LLM responses from being printed.

- **Tests**
  - Enhanced tests to cover new CLI options and updated prompt formatting expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->