### PR TITLE
Add full-path display option (tree -f equivalent)

### DIFF
--- a/docs/src/architecture/modules.md
+++ b/docs/src/architecture/modules.md
@@ -20,6 +20,7 @@ This top-level module centralizes all configuration-related definitions for the 
 
 - **`listing.rs`**:
   - Defines `ListingOptions` struct for directory traversal settings.
+  - Includes `show_full_path` option to control whether formatters display full relative paths or just filenames.
 
 - **`filtering.rs`**:
   - Defines `FilteringOptions` struct for inclusion/exclusion patterns, gitignore settings, and the `prune_empty_directories` flag.
@@ -79,8 +80,8 @@ The `src/core/` directory houses the main operational logic of `rustree`.
 
 - **`formatter/`**: This sub-module is responsible for generating the final output string.
   - `base.rs`: Defines the `TreeFormatter` trait, which all specific formatters implement.
-  - `text_tree.rs`: Implements `TextTreeFormatter` for the classic `tree`-like text output. It uses `core::metadata::file_info::format_node_metadata` for consistent metadata display.
-  - `markdown.rs`: Implements `MarkdownFormatter` for generating Markdown lists. It also uses `core::metadata::file_info::format_node_metadata`.
+  - `text_tree.rs`: Implements `TextTreeFormatter` for the classic `tree`-like text output. It uses `core::metadata::file_info::format_node_metadata` for consistent metadata display. Supports full path display when `config.listing.show_full_path` is enabled.
+  - `markdown.rs`: Implements `MarkdownFormatter` for generating Markdown lists. It also uses `core::metadata::file_info::format_node_metadata`. Supports full path display when `config.listing.show_full_path` is enabled.
   - `mod.rs` (in `formatter`): Re-exports `OutputFormat` (as `LibOutputFormat`) from `src/config/output_format.rs`.
 
 - **`util.rs`**: Contains general utility functions like `is_hidden`, `format_size`, `truncate_string`.

--- a/docs/src/cli_usage/examples.md
+++ b/docs/src/cli_usage/examples.md
@@ -100,6 +100,78 @@ Here are some practical examples of how to use `rustree` from the command line.
    rustree --sort-by none ./my_project
    ```
 
+11b. **Show full paths for all files (similar to tree -f):**
+
+   ```bash
+   rustree --full-path ./my_project
+   # or using short flag
+   rustree -f ./my_project
+   ```
+   
+   **Example output:**
+   ```
+   my_project/
+   ├── README.md
+   ├── src/
+   │   ├── src/main.rs
+   │   ├── src/lib.rs
+   │   └── src/utils/
+   │       └── src/utils/helper.rs
+   └── tests/
+       └── tests/integration_test.rs
+   
+   3 directories, 5 files
+   ```
+   
+   Notice how nested files show their full relative path from the scan root (e.g., `src/main.rs` instead of just `main.rs`).
+
+11c. **Combine full-path with other metadata for detailed analysis:**
+
+   ```bash
+   rustree -f -s --calculate-lines ./my_project
+   ```
+   
+   **Example output:**
+   ```
+   my_project/
+   ├── [   1024B] [L:  50] README.md
+   ├── src/
+   │   ├── [   2048B] [L: 150] src/main.rs
+   │   ├── [   1536B] [L: 100] src/lib.rs
+   │   └── src/utils/
+   │       └── [    512B] [L:  25] src/utils/helper.rs
+   └── tests/
+       └── [   1280B] [L:  75] tests/integration_test.rs
+   
+   3 directories, 4 files, 400 total lines, 6.25 KB total
+   ```
+   
+   This combines full paths with size and line count information, making it easy to identify specific files and their characteristics.
+
+11d. **Full-path output in Markdown format:**
+
+   ```bash
+   rustree -f --output-format markdown ./docs > file_structure.md
+   ```
+   
+   **Generated Markdown:**
+   ```markdown
+   # docs
+   
+   * README.md
+   * guides/
+     * guides/installation.md
+     * guides/usage.md
+     * guides/advanced/
+       * guides/advanced/configuration.md
+   * api/
+     * api/reference.md
+   
+   __3 directories, 5 files total__
+   ```
+   
+   Perfect for documentation where you want to show the complete file paths in a structured format.
+
 12. **Apply the `count-pluses` function to files and sort by its custom output:**
 
     ```bash

--- a/docs/src/library_usage/concepts.md
+++ b/docs/src/library_usage/concepts.md
@@ -14,6 +14,7 @@ This struct (defined in `src/config/tree_options.rs`) is central to controlling 
   - `max_depth`: The maximum depth of traversal.
   - `show_hidden`: Whether to include hidden files/directories.
   - `list_directories_only`: If `true`, only directories (including symlinks to directories) are included in the results.
+  - `show_full_path`: If `true`, formatters display the full relative path for each entry instead of just the filename. Equivalent to the CLI `-f`/`--full-path` flag.
 - **`filtering: FilteringOptions`** (from `src/config/filtering.rs`):
   - `match_patterns`: `Option<Vec<String>>` containing patterns to filter entries. Only entries matching any pattern will be included. Corresponds to the CLI `-P`/`--filter-include` options.
   - `ignore_patterns`: `Option<Vec<String>>` containing patterns to ignore entries. Entries matching any pattern will be excluded. Corresponds to the CLI `-I`/`--filter-exclude` options.
@@ -56,6 +57,7 @@ let config = RustreeLibConfig {
         max_depth: Some(3),
         show_hidden: false,
         list_directories_only: false,
+        show_full_path: true, // Show full relative paths for files
         ..Default::default()
     },
     filtering: FilteringOptions {

--- a/docs/src/library_usage/examples.md
+++ b/docs/src/library_usage/examples.md
@@ -45,6 +45,58 @@ fn main() -> Result<(), RustreeError> {
 }
 ```
 
+### Example 1b: Tree Listing with Full Paths
+
+This example demonstrates using the `show_full_path` option to display complete relative paths.
+
+```rust
+use rustree::{
+    get_tree_nodes, format_nodes, RustreeLibConfig, LibOutputFormat, RustreeError,
+    InputSourceOptions, ListingOptions,
+};
+use std::path::Path;
+
+fn main() -> Result<(), RustreeError> {
+    let target_path = "./src";
+    let path_obj = Path::new(target_path);
+
+    let config = RustreeLibConfig {
+        input_source: InputSourceOptions {
+            root_display_name: "src".to_string(),
+            root_is_directory: path_obj.is_dir(),
+            ..Default::default()
+        },
+        listing: ListingOptions {
+            max_depth: Some(3),
+            show_full_path: true, // Enable full path display
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(path_obj, &config)?;
+    let output_string = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+    
+    println!("{}", output_string);
+    
+    // Output will show:
+    // src/
+    // ├── src/main.rs
+    // ├── src/lib.rs
+    // └── src/utils/
+    //     └── src/utils/helper.rs
+    // 
+    // Instead of just:
+    // src/
+    // ├── main.rs
+    // ├── lib.rs
+    // └── utils/
+    //     └── helper.rs
+
+    Ok(())
+}
+```
+
 ### Example 2: Reporting Sizes and Sorting
 
 This example demonstrates reporting file sizes and sorting by size in descending order.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,10 +1,9 @@
 // src/cli/args.rs
-use crate::cli::filtering::{apply_function, exclude, gitignore_rules, include};
-use crate::cli::listing::{depth, directory_only, hidden};
+use crate::cli::filtering::{apply_function, exclude, gitignore_rules, include, pruning};
+use crate::cli::listing::{depth, directory_only, full_path, hidden};
 use crate::cli::llm;
 use crate::cli::metadata::{date, size, stats};
 use crate::cli::output::format;
-use crate::cli::pruning; // Import the new pruning module
 use crate::cli::sorting::order;
 use clap::Parser;
 use std::path::PathBuf;
@@ -28,6 +27,9 @@ pub struct CliArgs {
 
     #[command(flatten)]
     pub directory_only: directory_only::DirectoryOnlyArgs,
+
+    #[command(flatten)]
+    pub full_path: full_path::FullPathArgs,
 
     #[command(flatten)]
     pub size: size::SizeArgs,

--- a/src/cli/filtering/mod.rs
+++ b/src/cli/filtering/mod.rs
@@ -2,3 +2,4 @@ pub mod apply_function;
 pub mod exclude;
 pub mod gitignore_rules;
 pub mod include;
+pub mod pruning;

--- a/src/cli/filtering/pruning.rs
+++ b/src/cli/filtering/pruning.rs
@@ -1,4 +1,4 @@
-// src/cli/pruning.rs
+// src/cli/filtering/pruning.rs
 use clap::Args;
 
 #[derive(Args, Debug)]

--- a/src/cli/listing/full_path.rs
+++ b/src/cli/listing/full_path.rs
@@ -1,0 +1,8 @@
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct FullPathArgs {
+    /// Print the full path prefix for each file (Original tree: -f)
+    #[arg(short = 'f', long = "full-path")]
+    pub show_full_path: bool,
+}

--- a/src/cli/listing/mod.rs
+++ b/src/cli/listing/mod.rs
@@ -1,3 +1,4 @@
 pub mod depth;
 pub mod directory_only;
+pub mod full_path;
 pub mod hidden;

--- a/src/cli/mapping.rs
+++ b/src/cli/mapping.rs
@@ -66,6 +66,7 @@ pub fn map_cli_to_lib_config(cli_args: &CliArgs) -> Result<RustreeLibConfig, std
             max_depth: cli_args.depth.max_depth,
             show_hidden: cli_args.all_files.show_hidden,
             list_directories_only: cli_args.directory_only.list_directories_only,
+            show_full_path: cli_args.full_path.show_full_path,
         },
         filtering: FilteringOptions {
             match_patterns: cli_args.include.match_patterns.clone(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,6 @@
 // src/cli/mod.rs
 mod args;
 mod mapping; // CLI to library configuration mapping functions
-pub mod pruning; // New module for pruning arguments
 
 // Re-export the main CLI args struct.
 pub use args::CliArgs;

--- a/src/config/listing.rs
+++ b/src/config/listing.rs
@@ -7,4 +7,6 @@ pub struct ListingOptions {
     pub show_hidden: bool,
     /// Whether to list only directories, excluding files.
     pub list_directories_only: bool,
+    /// Whether to show the full relative path for each file/directory.
+    pub show_full_path: bool,
 }

--- a/src/core/formatter/text_tree.rs
+++ b/src/core/formatter/text_tree.rs
@@ -149,7 +149,24 @@ impl TreeFormatter for TextTreeFormatter {
             let metadata_string = format_node_metadata(node, config, MetadataStyle::Text);
             write!(output, "{}", metadata_string)?;
 
-            write!(output, "{}", node.name)?;
+            // Show full path or just name based on configuration
+            if config.listing.show_full_path {
+                // For full path, we need to make it relative to the current directory
+                let display_path = if let Some(scan_root) = &scan_root_path_opt {
+                    // Make path relative to scan root
+                    node.path
+                        .strip_prefix(scan_root)
+                        .unwrap_or(&node.path)
+                        .to_string_lossy()
+                        .to_string()
+                } else {
+                    // Fallback to just the name if no scan root
+                    node.name.clone()
+                };
+                write!(output, "{}", display_path)?;
+            } else {
+                write!(output, "{}", node.name)?;
+            }
             if node.node_type == NodeType::Directory {
                 write!(output, "/")?;
             }

--- a/tests/full_path_cli_tests.rs
+++ b/tests/full_path_cli_tests.rs
@@ -1,0 +1,238 @@
+// tests/full_path_cli_tests.rs
+
+#![allow(clippy::needless_update)]
+
+use anyhow::Result;
+use std::fs::{self, File};
+use std::io::Write;
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+
+/// Helper function to create a test directory structure for CLI testing
+fn setup_cli_test_directory() -> Result<TempDir> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let root = temp_dir.path();
+
+    // Create structure:
+    // test_root/
+    //   ├── file_a.txt
+    //   ├── nested/
+    //   │   ├── file_b.txt
+    //   │   └── deep/
+    //   │       └── file_c.txt
+    //   └── other/
+    //       └── file_d.txt
+
+    let nested = root.join("nested");
+    let deep = nested.join("deep");
+    let other = root.join("other");
+
+    fs::create_dir_all(&nested)?;
+    fs::create_dir_all(&deep)?;
+    fs::create_dir_all(&other)?;
+
+    File::create(root.join("file_a.txt"))?.write_all(b"content a")?;
+    File::create(nested.join("file_b.txt"))?.write_all(b"content b")?;
+    File::create(deep.join("file_c.txt"))?.write_all(b"content c")?;
+    File::create(other.join("file_d.txt"))?.write_all(b"content d")?;
+
+    Ok(temp_dir)
+}
+
+/// Helper function to run the rustree binary with given arguments
+fn run_rustree_binary(args: &[&str]) -> Result<String> {
+    let mut cmd_args = vec!["run", "--"];
+    cmd_args.extend_from_slice(args);
+
+    let output = Command::new("cargo")
+        .args(&cmd_args)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Binary execution failed: {}", stderr);
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+#[test]
+fn test_cli_full_path_basic_functionality() -> Result<()> {
+    let temp_dir = setup_cli_test_directory()?;
+    let root_path = temp_dir.path();
+
+    // Test without full-path flag
+    let output_normal = run_rustree_binary(&[root_path.to_str().unwrap()])?;
+
+    // Test with full-path flag
+    let output_full_path = run_rustree_binary(&["-f", root_path.to_str().unwrap()])?;
+
+    // Normal output should show just filenames
+    assert!(output_normal.contains("file_b.txt"));
+    assert!(output_normal.contains("file_c.txt"));
+    assert!(output_normal.contains("file_d.txt"));
+
+    // Full-path output should show relative paths
+    assert!(output_full_path.contains("nested/file_b.txt"));
+    assert!(output_full_path.contains("nested/deep/file_c.txt"));
+    assert!(output_full_path.contains("other/file_d.txt"));
+
+    // Both should show root-level files the same way
+    assert!(output_normal.contains("file_a.txt"));
+    assert!(output_full_path.contains("file_a.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_full_path_with_depth_limit() -> Result<()> {
+    let temp_dir = setup_cli_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let output = run_rustree_binary(&["-f", "-L", "2", root_path.to_str().unwrap()])?;
+
+    // Should show paths up to depth 2
+    assert!(output.contains("nested/file_b.txt"));
+    assert!(output.contains("other/file_d.txt"));
+
+    // Should NOT show depth 3 files
+    assert!(!output.contains("nested/deep/file_c.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_full_path_with_markdown_format() -> Result<()> {
+    let temp_dir = setup_cli_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let output = run_rustree_binary(&[
+        "-f",
+        "--output-format",
+        "markdown",
+        root_path.to_str().unwrap(),
+    ])?;
+
+    // Should be markdown format with full paths
+    assert!(output.starts_with("#"));
+    assert!(output.contains("* nested/file_b.txt"));
+    assert!(output.contains("* nested/deep/file_c.txt"));
+    assert!(output.contains("* other/file_d.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_full_path_with_directories_only() -> Result<()> {
+    let temp_dir = setup_cli_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let output = run_rustree_binary(&["-f", "-d", root_path.to_str().unwrap()])?;
+
+    // Should show directory paths only
+    assert!(output.contains("nested/deep/"));
+
+    // Should NOT show any files
+    assert!(!output.contains("file_a.txt"));
+    assert!(!output.contains("nested/file_b.txt"));
+    assert!(!output.contains("nested/deep/file_c.txt"));
+    assert!(!output.contains("other/file_d.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_full_path_with_size_metadata() -> Result<()> {
+    let temp_dir = setup_cli_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let output = run_rustree_binary(&["-f", "-s", root_path.to_str().unwrap()])?;
+
+    // Should show both size metadata and full paths
+    // Look for pattern like "[     9B] nested/file_b.txt"
+    let lines: Vec<&str> = output.lines().collect();
+    let file_b_line = lines.iter().find(|line| line.contains("nested/file_b.txt"));
+    assert!(
+        file_b_line.is_some(),
+        "Should contain full path for file_b.txt"
+    );
+
+    let file_b_line = file_b_line.unwrap();
+    assert!(
+        file_b_line.contains("[") && file_b_line.contains("B]"),
+        "Should show size metadata with full path: {}",
+        file_b_line
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_help_contains_full_path_option() -> Result<()> {
+    let output = Command::new("cargo")
+        .args(["run", "--", "--help"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should contain our full-path option
+    assert!(stdout.contains("--full-path") || stdout.contains("-f"));
+    assert!(stdout.contains("Print the full path prefix"));
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_full_path_short_and_long_flags() -> Result<()> {
+    let temp_dir = setup_cli_test_directory()?;
+    let root_path = temp_dir.path();
+
+    // Test short flag
+    let output_short = run_rustree_binary(&["-f", root_path.to_str().unwrap()])?;
+
+    // Test long flag
+    let output_long = run_rustree_binary(&["--full-path", root_path.to_str().unwrap()])?;
+
+    // Both should produce the same output
+    assert_eq!(output_short, output_long);
+
+    // Both should show full paths
+    assert!(output_short.contains("nested/file_b.txt"));
+    assert!(output_long.contains("nested/file_b.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_full_path_with_multiple_flags() -> Result<()> {
+    let temp_dir = setup_cli_test_directory()?;
+    let root_path = temp_dir.path();
+
+    // Test combination with hidden files and size
+    let output = run_rustree_binary(&["-f", "-a", "-s", root_path.to_str().unwrap()])?;
+
+    // Should work without errors and show full paths
+    assert!(output.contains("nested/file_b.txt"));
+    assert!(output.contains("[") && output.contains("B]")); // Size info
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_full_path_empty_directory() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let root_path = temp_dir.path();
+
+    let output = run_rustree_binary(&["-f", root_path.to_str().unwrap()])?;
+
+    // Empty directory should still work (root directory counts as 1 directory)
+    assert!(output.contains("1 directory, 0 files"));
+
+    Ok(())
+}

--- a/tests/full_path_tests.rs
+++ b/tests/full_path_tests.rs
@@ -1,0 +1,327 @@
+// tests/full_path_tests.rs
+
+#![allow(clippy::needless_update)]
+
+use anyhow::Result;
+use rustree::{
+    LibOutputFormat, ListingOptions, MetadataOptions, MiscOptions, RustreeLibConfig, format_nodes,
+    get_tree_nodes,
+};
+use std::fs::{self, File};
+use std::io::Write;
+use tempfile::TempDir;
+
+/// Helper function to create a test directory structure for full-path testing
+fn setup_full_path_test_directory() -> Result<TempDir> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let root = temp_dir.path();
+
+    // Create nested structure:
+    // test_root/
+    //   ├── file1.txt
+    //   ├── dir1/
+    //   │   ├── file2.txt
+    //   │   └── subdir/
+    //   │       └── file3.txt
+    //   └── dir2/
+    //       └── file4.txt
+
+    let dir1 = root.join("dir1");
+    let dir2 = root.join("dir2");
+    let subdir = dir1.join("subdir");
+
+    fs::create_dir_all(&dir1)?;
+    fs::create_dir_all(&dir2)?;
+    fs::create_dir_all(&subdir)?;
+
+    File::create(root.join("file1.txt"))?.write_all(b"content1")?;
+    File::create(dir1.join("file2.txt"))?.write_all(b"content2")?;
+    File::create(subdir.join("file3.txt"))?.write_all(b"content3")?;
+    File::create(dir2.join("file4.txt"))?.write_all(b"content4")?;
+
+    Ok(temp_dir)
+}
+
+#[test]
+fn test_full_path_flag_disabled_shows_names_only() -> Result<()> {
+    let temp_dir = setup_full_path_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: false, // Disabled
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+
+    // Should show only filenames, not full paths
+    assert!(output.contains("file1.txt"));
+    assert!(output.contains("file2.txt"));
+    assert!(output.contains("file3.txt"));
+    assert!(output.contains("file4.txt"));
+
+    // Should NOT contain full paths like "dir1/file2.txt"
+    assert!(!output.contains("dir1/file2.txt"));
+    assert!(!output.contains("dir1/subdir/file3.txt"));
+    assert!(!output.contains("dir2/file4.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_full_path_flag_enabled_shows_full_paths() -> Result<()> {
+    let temp_dir = setup_full_path_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: true, // Enabled
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+
+    // Should show full paths for nested files
+    assert!(output.contains("dir1/file2.txt"));
+    assert!(output.contains("dir1/subdir/file3.txt"));
+    assert!(output.contains("dir2/file4.txt"));
+
+    // Root-level files should still show just their name (no path prefix needed)
+    assert!(output.contains("file1.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_full_path_with_markdown_format() -> Result<()> {
+    let temp_dir = setup_full_path_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Markdown, &config)?;
+
+    // Should show full paths in markdown format
+    assert!(output.contains("* dir1/file2.txt"));
+    assert!(output.contains("* dir1/subdir/file3.txt"));
+    assert!(output.contains("* dir2/file4.txt"));
+
+    // Should contain markdown list structure
+    assert!(output.contains("* file1.txt"));
+    assert!(output.contains("* dir1/"));
+    assert!(output.contains("  * dir1/subdir/"));
+
+    Ok(())
+}
+
+#[test]
+fn test_full_path_with_depth_limit() -> Result<()> {
+    let temp_dir = setup_full_path_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: true,
+            max_depth: Some(2), // Limit to 2 levels
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+
+    // Should show paths up to depth 2
+    assert!(output.contains("dir1/file2.txt"));
+    assert!(output.contains("dir2/file4.txt"));
+
+    // Should NOT show depth 3 files
+    assert!(!output.contains("dir1/subdir/file3.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_full_path_with_directories_only_mode() -> Result<()> {
+    let temp_dir = setup_full_path_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: true,
+            list_directories_only: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+
+    // Should show directory paths
+    assert!(output.contains("dir1/subdir/"));
+
+    // Should NOT show any files (directories only mode)
+    assert!(!output.contains("file1.txt"));
+    assert!(!output.contains("dir1/file2.txt"));
+    assert!(!output.contains("dir1/subdir/file3.txt"));
+    assert!(!output.contains("dir2/file4.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_full_path_preserves_directory_suffix() -> Result<()> {
+    let temp_dir = setup_full_path_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+
+    // Directories should still have trailing slash
+    assert!(output.contains("dir1/"));
+    assert!(output.contains("dir2/"));
+    assert!(output.contains("dir1/subdir/"));
+
+    // Files should not have trailing slash
+    assert!(output.contains("dir1/file2.txt"));
+    assert!(!output.contains("dir1/file2.txt/"));
+
+    Ok(())
+}
+
+#[test]
+fn test_full_path_with_metadata() -> Result<()> {
+    let temp_dir = setup_full_path_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: true,
+            ..Default::default()
+        },
+        metadata: MetadataOptions {
+            show_size_bytes: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+
+    // Should show both metadata and full paths
+    // Look for pattern like "[     8B] dir1/file2.txt"
+    let lines: Vec<&str> = output.lines().collect();
+    let file2_line = lines.iter().find(|line| line.contains("dir1/file2.txt"));
+    assert!(
+        file2_line.is_some(),
+        "Should contain full path for file2.txt"
+    );
+
+    let file2_line = file2_line.unwrap();
+    assert!(
+        file2_line.contains("[") && file2_line.contains("B]"),
+        "Should show size metadata with full path: {}",
+        file2_line
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_full_path_empty_directory() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let root_path = temp_dir.path();
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+
+    // Empty directory should still work
+    assert!(output.contains("0 directories, 0 files"));
+
+    Ok(())
+}
+
+#[test]
+fn test_full_path_single_file() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let root_path = temp_dir.path();
+
+    File::create(root_path.join("single.txt"))?.write_all(b"content")?;
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+
+    // Single file at root should show just filename (no path prefix needed)
+    assert!(output.contains("single.txt"));
+    assert!(!output.contains("/single.txt"));
+
+    Ok(())
+}
+
+#[test]
+fn test_full_path_no_summary_report() -> Result<()> {
+    let temp_dir = setup_full_path_test_directory()?;
+    let root_path = temp_dir.path();
+
+    let config = RustreeLibConfig {
+        listing: ListingOptions {
+            show_full_path: true,
+            ..Default::default()
+        },
+        misc: MiscOptions {
+            no_summary_report: true,
+        },
+        ..Default::default()
+    };
+
+    let nodes = get_tree_nodes(root_path, &config)?;
+    let output = format_nodes(&nodes, LibOutputFormat::Text, &config)?;
+
+    // Should show full paths but no summary
+    assert!(output.contains("dir1/file2.txt"));
+    assert!(output.contains("dir1/subdir/file3.txt"));
+    assert!(!output.contains("directories,"));
+    assert!(!output.contains("files"));
+
+    Ok(())
+}


### PR DESCRIPTION
**PR Description:**

This PR introduces a new feature to `rustree` that allows users to display the full relative path for each file and directory in the output, similar to the `tree -f` command.

**Key Changes:**

*   **Full Path Display (`-f`/`--full-path`):**
    *   Added a new CLI flag `-f` (short) and `--full-path` (long) to enable this mode.
    *   Introduced a `show_full_path: bool` option in `config::ListingOptions` for library users.
    *   Both `TextTreeFormatter` and `MarkdownFormatter` now support displaying full paths when this option is enabled.
    *   The displayed path is relative to the scan root (the directory being analyzed).

*   **Documentation Updates:**
    *   Updated architecture documentation (`architecture/modules.md`) to reflect the new option and formatter behavior.
    *   Added new CLI usage examples (`cli_usage/examples.md`) demonstrating the full path functionality, including combinations with other options (e.g., metadata, Markdown output).
    *   Updated library usage documentation (`library_usage/concepts.md` and `library_usage/examples.md`) to cover the new `show_full_path` configuration option and provide an example.

*   **Testing:**
    *   Added comprehensive integration tests for the CLI behavior in `tests/full_path_cli_tests.rs`.
    *   Added unit/integration tests for the library functionality related to full path display in `tests/full_path_tests.rs`.

*   **Code Reorganization:**
    *   Moved the `pruning.rs` CLI argument module from `src/cli/pruning.rs` to `src/cli/filtering/pruning.rs` for better organization of CLI argument modules.

**How to Use:**

**CLI:**
```bash
# Display full paths in standard text output
rustree -f ./my_project
rustree --full-path ./my_project

# Display full paths in Markdown format
rustree -f --output-format markdown ./docs

# Combine with other options like size and line count
rustree -f -s --calculate-lines ./my_project
```

**Library:**
```rust
use rustree::{RustreeLibConfig, ListingOptions, /* ... other imports ... */};

let config = RustreeLibConfig {
    listing: ListingOptions {
        show_full_path: true, // Enable full path display
        // ... other listing options ...
        ..Default::default()
    },
    // ... other config options ...
    ..Default::default()
};

// ... use config with get_tree_nodes and format_nodes ...
```

This feature enhances the utility of `rustree` for scenarios where knowing the complete relative path of each item is crucial, such as in documentation generation, script input, or detailed file system analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for displaying full relative file and directory paths in CLI and library outputs via the new `--full-path` (`-f`) flag or configuration option.
  - Both text tree and Markdown output formats now support full path display.

- **Documentation**
  - Updated documentation and examples to illustrate the new full path option in CLI and library usage.
  - Added new usage examples and detailed explanations for the full path feature.

- **Tests**
  - Introduced comprehensive tests verifying correct behavior of full path display across scenarios, formats, and option combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->