### PR TITLE
Introduce Size-Based Filtering For File Listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ diff.txt
 
 # For supercat
 .hide
+
+# AI folders

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,5 +1,7 @@
 // src/cli/args.rs
-use crate::cli::filtering::{apply_function, exclude, gitignore_rules, include, pruning};
+use crate::cli::filtering::{
+    apply_function, exclude, gitignore_rules, include, pruning, size_filter,
+};
 use crate::cli::listing::{depth, directory_only, full_path, hidden};
 use crate::cli::llm;
 use crate::cli::metadata::{date, size, stats};
@@ -51,6 +53,9 @@ pub struct CliArgs {
 
     #[command(flatten)]
     pub gitignore: gitignore_rules::GitignoreArgs,
+
+    #[command(flatten)]
+    pub size_filter: size_filter::SizeFilterArgs,
 
     #[command(flatten)]
     pub apply_function_filter: apply_function::ApplyFunctionFilterArgs,

--- a/src/cli/filtering/mod.rs
+++ b/src/cli/filtering/mod.rs
@@ -3,3 +3,4 @@ pub mod exclude;
 pub mod gitignore_rules;
 pub mod include;
 pub mod pruning;
+pub mod size_filter;

--- a/src/cli/filtering/size_filter.rs
+++ b/src/cli/filtering/size_filter.rs
@@ -1,0 +1,18 @@
+// src/cli/filtering/size_filter.rs
+
+//! CLI arguments for size-based filtering (`--min-file-size`, `--max-file-size`).
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct SizeFilterArgs {
+    /// Only include files whose size is **at least** this value.
+    /// Accepts suffixes K, M, G for kibibytes, mebibytes, gibibytes (base-1024).
+    #[arg(long = "min-file-size", value_name = "SIZE")]
+    pub min_file_size: Option<String>,
+
+    /// Only include files whose size is **at most** this value.
+    /// Accepts suffixes K, M, G for kibibytes, mebibytes, gibibytes (base-1024).
+    #[arg(long = "max-file-size", value_name = "SIZE")]
+    pub max_file_size: Option<String>,
+}

--- a/src/cli/llm.rs
+++ b/src/cli/llm.rs
@@ -90,7 +90,13 @@ pub struct LlmArgs {
     #[arg(long)]
     pub dry_run: bool,
 
-    /// Format dry-run output in a human-friendly markdown format
-    #[arg(long, requires = "dry_run")]
+    /// If present, format certain outputs in a more human-readable style.
+    ///
+    /// Originally this flag controlled the LLM `--dry-run` pretty printer.
+    /// It is now reused by the core listing functionality to display file
+    /// sizes in a human-readable form (e.g. `1.2 MB` instead of `1234567B`).
+    /// Retains its original role for LLM dry-run but no longer requires
+    /// `--dry-run` to be passed.
+    #[arg(long)]
     pub human_friendly: bool,
 }

--- a/src/cli/output/mod.rs
+++ b/src/cli/output/mod.rs
@@ -7,4 +7,7 @@ pub enum CliOutputFormat {
     Text,
     /// Markdown list format.
     Markdown,
+
+    /// JSON format (pretty-printed array).
+    Json,
 }

--- a/src/config/filtering.rs
+++ b/src/config/filtering.rs
@@ -30,4 +30,10 @@ pub struct FilteringOptions {
     /// Patterns to exclude when applying functions. Files/dirs matching these patterns will skip function application.
     /// Corresponds to CLI --apply-exclude.
     pub apply_exclude_patterns: Option<Vec<String>>,
+
+    // Size-based filtering
+    /// Minimum file size (in bytes) to include. `None` means no lower bound.
+    pub min_file_size: Option<u64>,
+    /// Maximum file size (in bytes) to include. `None` means no upper bound.
+    pub max_file_size: Option<u64>,
 }

--- a/src/config/metadata.rs
+++ b/src/config/metadata.rs
@@ -1,7 +1,9 @@
 use thiserror::Error;
 
 /// Errors that can occur when applying a function to file content.
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+use serde::Serialize;
+
+#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum ApplyFnError {
     /// Indicates that the function execution or calculation failed.
     #[error("Function calculation failed: {0}")]
@@ -34,6 +36,9 @@ pub enum BuiltInFunction {
 pub struct MetadataOptions {
     /// Whether to report file and directory sizes.
     pub show_size_bytes: bool,
+    /// Whether to format sizes in a human-readable form (e.g. "1.2 KB" instead of raw bytes).
+    /// This flag has an effect only when `show_size_bytes` is `true`.
+    pub human_readable_size: bool,
     /// Whether to report file permissions.
     pub report_permissions: bool,
     /// Whether to report last modification time.

--- a/src/config/output_format.rs
+++ b/src/config/output_format.rs
@@ -5,4 +5,7 @@ pub enum OutputFormat {
     Text,
     /// Markdown list format.
     Markdown,
+
+    /// JSON array of NodeInfo structs (pretty-printed).
+    Json,
 }

--- a/src/core/formatter/json.rs
+++ b/src/core/formatter/json.rs
@@ -1,0 +1,176 @@
+// src/core/formatter/json.rs
+
+//! JSON output formatter (hierarchical).
+//!
+//! Mimics the structure produced by `tree -J`: a nested hierarchy with
+//! `type`, `name`, and, for directories, a `contents` array.  At the end a
+//! synthetic `{ "type": "report", ... }` object is appended containing the
+//! total directory / file counts so downstream tools can replicate `tree`'s
+//! summary line.
+
+use crate::config::RustreeLibConfig;
+use crate::core::error::RustreeError;
+use crate::core::formatter::base::TreeFormatter;
+use crate::core::tree::{
+    builder,
+    node::{NodeInfo, NodeType},
+};
+
+use serde::Serialize;
+
+pub struct JsonFormatter;
+
+impl TreeFormatter for JsonFormatter {
+    fn format(
+        &self,
+        nodes: &[NodeInfo],
+        _config: &RustreeLibConfig,
+    ) -> Result<String, RustreeError> {
+        // Build temporary tree to restore hierarchy
+        let mut roots = builder::build_tree(nodes.to_vec())
+            .map_err(|e| RustreeError::TreeBuildError(format!("tree build failed: {}", e)))?;
+
+        let mut dirs = 0usize;
+        let mut files = 0usize;
+        let mut json_roots = Vec::new();
+
+        for root in &mut roots {
+            json_roots.push(convert_node(root, &mut dirs, &mut files));
+        }
+
+        // Wrap under synthetic root directory ("." by default)
+        dirs += 1; // count the synthetic root as directory, like GNU tree does
+        let root_name = ".".to_string();
+        let wrapped_root = JsonValue::Directory {
+            name: root_name,
+            contents: Some(json_roots),
+        };
+
+        let output_vec = vec![
+            wrapped_root,
+            JsonValue::Report(JsonReport {
+                directories: dirs,
+                files,
+            }),
+        ];
+
+        serde_json::to_string_pretty(&output_vec)
+            .map_err(|e| RustreeError::TreeBuildError(format!("JSON serialization failed: {}", e)))
+    }
+}
+
+/// Internal serialisable representation.
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum JsonValue {
+    #[serde(rename = "directory")]
+    Directory {
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        contents: Option<Vec<JsonValue>>,
+    },
+    #[serde(rename = "file")]
+    File { name: String },
+    #[serde(rename = "report")]
+    Report(JsonReport),
+}
+
+#[derive(Serialize)]
+struct JsonReport {
+    directories: usize,
+    files: usize,
+}
+
+fn convert_node(
+    node: &mut builder::TempNode,
+    dir_ctr: &mut usize,
+    file_ctr: &mut usize,
+) -> JsonValue {
+    match node.node_info.node_type {
+        NodeType::Directory => {
+            *dir_ctr += 1;
+            let mut child_vals = Vec::new();
+            for child in &mut node.children {
+                child_vals.push(convert_node(child, dir_ctr, file_ctr));
+            }
+            JsonValue::Directory {
+                name: node.node_info.name.clone(),
+                contents: if child_vals.is_empty() {
+                    None
+                } else {
+                    Some(child_vals)
+                },
+            }
+        }
+        _ => {
+            *file_ctr += 1;
+            JsonValue::File {
+                name: node.node_info.name.clone(),
+            }
+        }
+    }
+}
+
+// --------------------------------------------------
+// Tests
+// --------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::tree::node::NodeInfo;
+    use std::path::PathBuf;
+
+    #[test]
+    fn hierarchical_json_matches_expected_shape() {
+        let nodes = vec![
+            NodeInfo {
+                path: PathBuf::from("root"),
+                name: "root".into(),
+                node_type: NodeType::Directory,
+                depth: 0,
+                size: None,
+                permissions: None,
+                mtime: None,
+                change_time: None,
+                create_time: None,
+                line_count: None,
+                word_count: None,
+                custom_function_output: None,
+            },
+            NodeInfo {
+                path: PathBuf::from("root/file.txt"),
+                name: "file.txt".into(),
+                node_type: NodeType::File,
+                depth: 1,
+                size: None,
+                permissions: None,
+                mtime: None,
+                change_time: None,
+                create_time: None,
+                line_count: None,
+                word_count: None,
+                custom_function_output: None,
+            },
+        ];
+
+        let json_str = JsonFormatter
+            .format(&nodes, &RustreeLibConfig::default())
+            .unwrap();
+
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert!(v.is_array());
+        assert_eq!(v.as_array().unwrap().len(), 2); // synthetic root + report
+
+        // Root object is directory named "."
+        assert_eq!(v[0]["type"], "directory");
+        assert_eq!(v[0]["name"], ".");
+        // first child dir 'root'
+        assert_eq!(v[0]["contents"][0]["name"], "root");
+
+        // Report object
+        assert_eq!(v[1]["type"], "report");
+        assert_eq!(v[1]["directories"], 2); // synthetic root + actual dir
+        assert_eq!(v[1]["files"], 1);
+    }
+}

--- a/src/core/formatter/mod.rs
+++ b/src/core/formatter/mod.rs
@@ -25,6 +25,7 @@
 //! ```
 
 pub mod base;
+pub mod json;
 pub mod markdown;
 pub mod text_tree;
 
@@ -33,5 +34,6 @@ pub use crate::config::output_format::OutputFormat;
 
 // Re-export the core types for external use
 pub use base::TreeFormatter;
+pub use json::JsonFormatter;
 pub use markdown::MarkdownFormatter;
 pub use text_tree::TextTreeFormatter;

--- a/src/core/llm/preview.rs
+++ b/src/core/llm/preview.rs
@@ -9,7 +9,9 @@ use super::providers::LlmConfig;
 use serde_json::json;
 
 /// A human-readable preview of the outgoing LLM request.
-#[derive(Debug, Clone)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
 pub struct RequestPreview {
     pub provider: String,
     pub endpoint: String,
@@ -250,6 +252,31 @@ impl RequestPreview {
         }
 
         out
+    }
+}
+
+// first small serialization test
+#[cfg(test)]
+mod tests_serialization {
+    use super::*;
+    use crate::core::llm::providers::{LlmConfig, LlmProvider};
+    use std::time::Duration;
+
+    #[test]
+    fn preview_serializes_to_json_short() {
+        let cfg = LlmConfig {
+            provider: LlmProvider::OpenAi,
+            model: "gpt-4".to_string(),
+            api_key: "sk-abc".to_string(),
+            endpoint: None,
+            temperature: 0.2,
+            max_tokens: 64,
+            timeout: Duration::from_secs(30),
+        };
+        let preview = RequestPreview::from_config(&cfg, "hello");
+        let s = serde_json::to_string(&preview).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["provider"], "openai");
     }
 }
 

--- a/src/core/metadata/mod.rs
+++ b/src/core/metadata/mod.rs
@@ -13,6 +13,7 @@ pub mod time_formatter;
 
 use crate::config::{RustreeLibConfig, metadata::BuiltInFunction};
 use crate::core::tree::node::{NodeInfo, NodeType};
+use crate::core::util::format_size;
 
 /// Aggregates metadata values from a collection of nodes.
 /// Used to calculate totals for the summary report.
@@ -140,14 +141,14 @@ impl MetadataAggregator {
         }
 
         if let Some(size) = self.size_total {
-            parts.push(format!("{} total", Self::format_size(size)));
+            parts.push(format!("{} total", format_size(size)));
         }
 
         // If we have function-based totals, include them separately
         if let Some(size) = self.size_from_function {
             if self.size_total.is_none() {
                 // Only show if not already showing size_total
-                parts.push(format!("{} total (from function)", Self::format_size(size)));
+                parts.push(format!("{} total (from function)", format_size(size)));
             }
         }
 
@@ -176,23 +177,11 @@ impl MetadataAggregator {
         result.chars().rev().collect()
     }
 
-    /// Formats a size in bytes to a human-readable format.
+    /// Formats a size in bytes to a human-readable string by delegating to the
+    /// shared helper in `core::util`.  This wrapper is kept to avoid breaking
+    /// existing public API and unit tests, while ensuring the formatting logic
+    /// itself lives in a single place.
     pub fn format_size(bytes: u64) -> String {
-        const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB"];
-        const THRESHOLD: f64 = 1024.0;
-
-        let mut size = bytes as f64;
-        let mut unit_index = 0;
-
-        while size >= THRESHOLD && unit_index < UNITS.len() - 1 {
-            size /= THRESHOLD;
-            unit_index += 1;
-        }
-
-        if unit_index == 0 {
-            format!("{} {}", bytes, UNITS[unit_index])
-        } else {
-            format!("{:.1} {}", size, UNITS[unit_index])
-        }
+        format_size(bytes)
     }
 }

--- a/src/core/tree/node.rs
+++ b/src/core/tree/node.rs
@@ -6,7 +6,9 @@ use std::time::SystemTime;
 ///
 /// This struct is populated by the directory walker and contains metadata and analysis
 /// results for each node in the directory tree.
-#[derive(Debug, Clone)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
 pub struct NodeInfo {
     /// The full path to the file system entry.
     pub path: PathBuf,
@@ -39,7 +41,7 @@ pub struct NodeInfo {
 }
 
 /// Enumerates the types of file system entries that `rustree` can represent.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum NodeType {
     /// Represents a regular file.
     File,

--- a/src/core/walker/filesystem.rs
+++ b/src/core/walker/filesystem.rs
@@ -172,7 +172,10 @@ pub fn walk_directory(
         };
 
         if let Some(meta) = resolved_metadata_for_node {
-            if config.metadata.show_size_bytes {
+            if config.metadata.show_size_bytes
+                || config.filtering.min_file_size.is_some()
+                || config.filtering.max_file_size.is_some()
+            {
                 node.size = Some(meta.len());
             }
             if config.metadata.show_last_modified {


### PR DESCRIPTION
This PR adds functionality to the CLI for filtering file listings based on their sizes by introducing `--min-file-size` and `--max-file-size` options.
What this PR does:
- Enables users to specify minimum and maximum file sizes for filtered output, enhancing the usability of file listings in the CLI.
Key changes:
- Added new CLI options `--min-file-size` and `--max-file-size` with appropriate argument parsing.
- Implemented size filtering logic to exclude files that do not meet the specified size criteria.
- Extended JSON output format to support size filter information for better integration with external tools.
Testing:
- Ensure correct behavior when specifying different size filters in CLI commands.
- Validate that only files within the specified size range are included in the output.
- Test with various unit suffixes (K, M, G) for input sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering files by minimum and maximum size via new CLI options, with support for human-readable size suffixes (K, M, G).
  - Introduced a JSON output format for CLI and LLM-related commands, providing structured data for easier post-processing.
  - Enhanced the human-friendly output flag to display file sizes in a readable format (e.g., "1.2 MB") in listings and dry-run outputs.
  - Enabled JSON serialization for LLM request previews and tree node data to improve integration and output flexibility.

- **Documentation**
  - Updated CLI usage documentation to describe new size-based filtering, JSON output format, and human-friendly size display options.

- **Bug Fixes**
  - Ensured file sizes are always available when size-based filtering is active.

- **Chores**
  - Minor update to `.gitignore` for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->