### PR TITLE
Add Support For External Command-Based Apply Functions

### DIFF
--- a/src/cli/metadata/stats.rs
+++ b/src/cli/metadata/stats.rs
@@ -15,4 +15,22 @@ pub struct FileStatsArgs {
     /// Apply a built-in function to file contents and display the result.
     #[arg(long)]
     pub apply_function: Option<CliBuiltInFunction>,
+
+    /// Apply an external command to file contents; mutually exclusive with
+    /// `--apply-function`.
+    #[arg(long = "apply-function-cmd", value_name = "CMD")]
+    pub apply_function_cmd: Option<String>,
+
+    /// Specify the result kind for the external command: "number", "bytes", or "text".
+    /// Defaults to "text".
+    #[arg(
+        long = "apply-function-cmd-kind",
+        value_name = "KIND",
+        default_value = "text"
+    )]
+    pub apply_function_cmd_kind: String,
+
+    /// Timeout in seconds for the external command (default 5 seconds).
+    #[arg(long = "apply-timeout", default_value_t = 5)]
+    pub apply_function_timeout: u64,
 }

--- a/tests/external_function_display_tests.rs
+++ b/tests/external_function_display_tests.rs
@@ -1,0 +1,92 @@
+//! Tests covering the UI behaviour of external command apply-functions.
+
+use rustree::config::metadata::{ExternalFunction, FunctionOutputKind};
+use rustree::config::{ListingOptions, MetadataOptions, RustreeLibConfig};
+use rustree::core::tree::node::NodeType;
+use rustree::{LibOutputFormat, format_nodes, get_tree_nodes};
+use std::fs::{self, File};
+use std::io::Write;
+
+/// Helper to build a minimal config that only sets the external function.
+fn make_config(ext_fn: ExternalFunction) -> RustreeLibConfig {
+    RustreeLibConfig {
+        metadata: MetadataOptions {
+            external_function: Some(ext_fn),
+            ..Default::default()
+        },
+        listing: ListingOptions {
+            // ensure deterministic order for tests
+            max_depth: None,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_external_number_aggregation_and_display() {
+    let tmp = tempfile::TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+
+    // Create two files: 3 lines + 4 lines => expected total 7.
+    let mut f1 = File::create(dir.join("a.txt")).unwrap();
+    writeln!(f1, "one\ntwo\nthree").unwrap();
+
+    let mut f2 = File::create(dir.join("b.txt")).unwrap();
+    writeln!(f2, "1\n2\n3\n4").unwrap();
+
+    let ext_fn = ExternalFunction {
+        cmd_template: "wc -l < {}".to_string(),
+        timeout_secs: 5,
+        kind: FunctionOutputKind::Number,
+    };
+
+    let cfg = make_config(ext_fn);
+
+    let nodes = get_tree_nodes(dir, &cfg).expect("nodes");
+    // Ensure we collected output for each file
+    for n in &nodes {
+        if n.node_type == NodeType::File {
+            assert!(matches!(n.custom_function_output, Some(Ok(_))));
+        }
+    }
+
+    let out = format_nodes(&nodes, LibOutputFormat::Text, &cfg).expect("format");
+
+    assert!(out.contains("[F: \"3\"]"));
+    assert!(out.contains("[F: \"4\"]"));
+    assert!(out.contains("7 total (custom)"));
+}
+
+#[test]
+fn test_external_text_cat_style_header_and_content() {
+    let tmp = tempfile::TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+
+    let file_path = dir.join("hello.txt");
+    fs::write(&file_path, "Hello external world!\n").unwrap();
+
+    let ext_cmd = "cat {}".to_string();
+    let ext_fn = ExternalFunction {
+        cmd_template: ext_cmd.clone(),
+        timeout_secs: 5,
+        kind: FunctionOutputKind::Text,
+    };
+
+    let cfg = make_config(ext_fn);
+    let nodes = get_tree_nodes(dir, &cfg).expect("nodes");
+    let out = format_nodes(&nodes, LibOutputFormat::Text, &cfg).expect("format");
+
+    // No inline F markers for text mode
+    assert!(!out.contains("[F:"));
+
+    // The custom header should be present
+    let expected_header = format!(
+        "--- Results of applying '{}' to relevant files ---",
+        ext_cmd
+    );
+    assert!(out.contains(&expected_header));
+
+    // And the content of the file should follow under === <path> ===
+    assert!(out.contains("Hello external world!"));
+}

--- a/tests/external_function_tests.rs
+++ b/tests/external_function_tests.rs
@@ -1,0 +1,24 @@
+use rustree::config::metadata::{ExternalFunction, FunctionOutputKind};
+use rustree::core::metadata::file_info::apply_external_to_file;
+use std::fs::File;
+use std::io::Write;
+
+#[test]
+fn test_apply_external_function_number() {
+    // Prepare a temporary file with known content (3 lines)
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file_path = dir.path().join("test.txt");
+    {
+        let mut f = File::create(&file_path).unwrap();
+        writeln!(f, "line1\nline2\nline3").unwrap();
+    }
+
+    let ext_fn = ExternalFunction {
+        cmd_template: "wc -l < {}".to_string(),
+        timeout_secs: 5,
+        kind: FunctionOutputKind::Number,
+    };
+
+    let res = apply_external_to_file(&file_path, &ext_fn).expect("ok");
+    assert_eq!(res.trim(), "3");
+}


### PR DESCRIPTION
This PR introduces functionality to execute external commands on file contents, enhancing the flexibility of the file processing capabilities.

## What this PR does:
- Adds the ability to specify external commands to be applied to file contents.
- Implements configuration options for defining external commands and parameters.

## Key changes:
- New config options for external commands in the `metadata` struct.
- Modified existing functions to incorporate the capability of handling external commands alongside built-in functions.
- Introduced a new function for executing external commands with error handling and timeout management.
- Updated JSON formatter to display outputs from the newly introduced external functions.

## Testing notes:
- Introduced new tests to cover the functionality of external command execution and its impact on metadata aggregation and display.
- Validated command execution for different output types (number, text) and confirmed results are correctly aggregated.

## Notes:
- The timeout for executing external commands is set to 5 seconds by default.
- External commands must be specified in a mutually exclusive manner with built-in functions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for applying external command-line functions to files, with configurable command, output type (text, number, bytes), and timeout.
  - External function results are now included in both the tree output and summary, with aggregated totals for numeric and byte outputs.
  - JSON output now displays applied command metadata and results for each node.

- **Bug Fixes**
  - Improved error handling and reporting for external command execution and timeouts.

- **Tests**
  - Introduced tests to verify external function integration, aggregation, and display in both text and JSON outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->