### PR TITLE
Add Support For HTML Output Format

### DIFF
--- a/docs/src/cli_usage/options.md
+++ b/docs/src/cli_usage/options.md
@@ -180,8 +180,48 @@ These flags can be combined to specify a size range, e.g. `--min-file-size 10K -
 
 - `--output-format <FORMAT>`
   - Description: Specifies the output format.
-  - Possible values: `text` (default), `markdown`, `json`.
+  - Possible values: `text` (default), `markdown`, `json`, `html`.
   - Example: `rustree --output-format json | jq '.'`
+
+### HTML-specific flags (when `--output-format html` is selected)
+
+| Flag | Explanation | GNU tree analogue |
+|------|-------------|-------------------|
+| `--html-base-href <URL>` | Prepend `<URL>/` to every generated hyperlink.  If the URL already ends with a `/`, it is not duplicated. | `-H <URL>` |
+| `--html-strip-first-component` | Strip the first path component of every link *after* the base-href. Useful when you scan a sub-directory but want links rooted at the parent. | `-H -<URL>` |
+| `--html-no-links` | Disable generation of `<a href>` tags – the tree is plain text inside the `<pre>` block. | `--nolinks` |
+| `--html-intro-file <FILE>` | Use the contents of `FILE` instead of the built-in HTML header (everything before the `<pre>`).  Specify `/dev/null` or an empty file to suppress the header entirely. | `--hintro=<file>` |
+| `--html-outro-file <FILE>` | Use the contents of `FILE` instead of the default footer (everything after `</pre>`).  Pass `/dev/null` to omit. | `--houtro=<file>` |
+
+#### Quick examples
+
+• Embed a browseable tree of your `src/` folder on a website:
+
+```bash
+rustree src/ \
+        --output-format html \
+        --html-base-href https://www.example.com/src \
+        > src_index.html
+```
+
+• Same as above, but you ran the command in the repo-root and want to drop the leading `src/` component:
+
+```bash
+rustree --output-format html \
+        --html-base-href https://www.example.com \
+        --html-strip-first-component \
+        src/ > index.html
+```
+
+• Plain HTML (no links), custom header/footer:
+
+```bash
+rustree --output-format html \
+        --html-no-links \
+        --html-intro-file ./templates/intro.html \
+        --html-outro-file ./templates/outro.html \
+        > tree.html
+```
   - When combined with LLM flags (`--llm-ask`, `--llm-export`, or `--dry-run`) the program emits a single JSON object that bundles both the tree and the LLM section.  This makes it trivial to post-process or archive the entire interaction.  Example:
 
     ```bash

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ RusTree is a command-line tool and Rust library designed to display directory st
 - **Analyze Content:** Get insights like file sizes, modification dates, line counts, and word counts.
 - **Apply Custom Logic:** Use built-in functions (or extend with your own) to process file contents and report results.
 - **Sort Entries:** Organize the tree output by name, size, modification time, or other criteria.
-- **Flexible Output:** Choose between plain text tree format or Markdown.
+- **Flexible Output:** Choose between plain text tree format, Markdown, JSON, or a self-contained HTML page.
 - **Cross-Platform:** Built with Rust, aiming for compatibility across different operating systems.
 
 ## Who is this for?

--- a/docs/src/library_usage/concepts.md
+++ b/docs/src/library_usage/concepts.md
@@ -138,12 +138,12 @@ fn display_tree(nodes: &[NodeInfo], format: LibOutputFormat, config: &RustreeLib
 }
 ```
 
-This function takes the nodes, a `LibOutputFormat` enum (`Text` or `Markdown`, from `src/config/output_format.rs` and re-exported), and the `RustreeLibConfig` (as some config options affect formatting).
+This function takes the nodes, a `LibOutputFormat` enum (`Text`, `Markdown`, `Json`, or `Html`, from `src/config/output_format.rs` and re-exported), and the `RustreeLibConfig` (as some config options affect formatting).
 
 ### Key Enums
 
 - **`SortKey`**: `Name`, `Version`, `Size`, `MTime`, `ChangeTime`, `CreateTime`, `Words`, `Lines`, `Custom`, `None`. Defined in `src/config/sorting.rs`. Used in `RustreeLibConfig.sorting.sort_by`.
-- **`LibOutputFormat`**: `Text`, `Markdown`. Defined in `src/config/output_format.rs` (as `OutputFormat`). Used with `format_nodes()`.
+- **`LibOutputFormat`**: `Text`, `Markdown`, `Json`, `Html`. Defined in `src/config/output_format.rs` (as `OutputFormat`). Used with `format_nodes()`.
 - **`BuiltInFunction`**: 
   - File functions: `CountPluses` (counts '+' characters), `Cat` (returns full file content)
   - Directory functions: `CountFiles`, `CountDirectories`, `SizeTotal`, `DirStats`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -86,6 +86,9 @@ pub struct CliArgs {
     #[command(flatten, next_help_heading = "\x1b[1;37mOutput Options\x1b[0m")]
     pub format: format::FormatArgs,
 
+    #[command(flatten)]
+    pub html_output: crate::cli::output::html::HtmlOutputArgs,
+
     // LLM Options
     #[command(flatten, next_help_heading = "\x1b[1;31mLLM Options\x1b[0m")]
     pub llm: llm::LlmArgs,

--- a/src/cli/mapping.rs
+++ b/src/cli/mapping.rs
@@ -11,6 +11,7 @@ use crate::cli::sorting::CliSortKey;
 // Corrected imports using explicit paths from crate::config
 use crate::config::BuiltInFunction as LibBuiltInFunction;
 use crate::config::FilteringOptions;
+use crate::config::HtmlOptions;
 use crate::config::InputSourceOptions;
 use crate::config::ListingOptions;
 use crate::config::MetadataOptions;
@@ -180,6 +181,14 @@ pub fn map_cli_to_lib_config(cli_args: &CliArgs) -> Result<RustreeLibConfig, std
         misc: MiscOptions {
             no_summary_report: cli_args.format.no_summary_report,
         },
+
+        html: HtmlOptions {
+            base_href: cli_args.html_output.html_base_href.clone(),
+            strip_first_component: cli_args.html_output.html_strip_first_component,
+            custom_intro: cli_args.html_output.html_intro_file.clone(),
+            custom_outro: cli_args.html_output.html_outro_file.clone(),
+            include_links: !cli_args.html_output.html_no_links,
+        },
     })
 }
 
@@ -245,6 +254,7 @@ pub fn map_cli_to_lib_output_format(cli_output_format: Option<CliOutputFormat>) 
     match cli_output_format {
         Some(CliOutputFormat::Markdown) => LibOutputFormat::Markdown,
         Some(CliOutputFormat::Json) => LibOutputFormat::Json,
+        Some(CliOutputFormat::Html) => LibOutputFormat::Html,
         Some(CliOutputFormat::Text) | None => LibOutputFormat::Text, // Default to Text
     }
 }

--- a/src/cli/output/html.rs
+++ b/src/cli/output/html.rs
@@ -1,0 +1,46 @@
+// src/cli/output/html.rs
+
+//! CLI flags that are specific to the HTML output formatter.
+//!
+//! They are grouped under the same "Output Options" heading as the generic
+//! `--output-format` flag.
+
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct HtmlOutputArgs {
+    /// Base URL to prepend to generated links (equivalent to GNU tree's -H).
+    #[arg(
+        long = "html-base-href",
+        value_name = "URL",
+        help_heading = "HTML Options"
+    )]
+    pub html_base_href: Option<String>,
+
+    /// Strip the first path component from generated hyperlinks (mimics `-H -BASEHREF`).
+    #[arg(long = "html-strip-first-component", help_heading = "HTML Options")]
+    pub html_strip_first_component: bool,
+
+    /// Path to a file that contains HTML to be placed *before* the <pre> block.
+    #[arg(
+        long = "html-intro-file",
+        value_name = "FILE",
+        help_heading = "HTML Options"
+    )]
+    pub html_intro_file: Option<PathBuf>,
+
+    /// Path to a file that contains HTML to be placed *after* the <pre> block.
+    #[arg(
+        long = "html-outro-file",
+        value_name = "FILE",
+        help_heading = "HTML Options"
+    )]
+    pub html_outro_file: Option<PathBuf>,
+
+    /// Disable generation of <a href> hyperlinks inside the HTML tree.
+    #[arg(long = "html-no-links", help_heading = "HTML Options")]
+    pub html_no_links: bool,
+}
+
+// Default derive now covers the previous manual implementation.

--- a/src/cli/output/mod.rs
+++ b/src/cli/output/mod.rs
@@ -1,4 +1,5 @@
 pub mod format;
+pub mod html;
 
 /// Defines the possible output formats selectable via the CLI.
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq, Eq)]
@@ -10,4 +11,7 @@ pub enum CliOutputFormat {
 
     /// JSON format (pretty-printed array).
     Json,
+
+    /// HTML output (tree wrapped in <pre> inside an HTML page).
+    Html,
 }

--- a/src/config/html.rs
+++ b/src/config/html.rs
@@ -1,0 +1,45 @@
+// src/config/html.rs
+
+//! Configuration specific to HTML output.
+//!
+//! These options are only consulted when `--output-format html` (or
+//! `LibOutputFormat::Html`) is active.  They correspond closely to the legacy
+//! flags provided by GNU `tree` (-H, --nolinks, --hintro, --houtro).
+
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct HtmlOptions {
+    /// If present, this string is prepended to every hyperlink that is
+    /// generated (e.g. "https://example.org/").  It should NOT contain a
+    /// trailing slash; the formatter takes care of inserting one.
+    pub base_href: Option<String>,
+
+    /// When `true`, the first path component of the generated relative link is
+    /// stripped.  This mimics the behaviour of GNU tree's "-H -baseHREF".
+    pub strip_first_component: bool,
+
+    /// Use a custom intro fragment (HTML that comes *before* the `<pre>` tree)
+    /// instead of the built-in default.
+    pub custom_intro: Option<PathBuf>,
+
+    /// Use a custom outro fragment (HTML that comes *after* the `<pre>` tree)
+    /// instead of the built-in default.
+    pub custom_outro: Option<PathBuf>,
+
+    /// Whether to generate `<a href>` hyperlinks.  If `false`, only plain text
+    /// (escaped) file names are shown.
+    pub include_links: bool,
+}
+
+impl Default for HtmlOptions {
+    fn default() -> Self {
+        Self {
+            base_href: None,
+            strip_first_component: false,
+            custom_intro: None,
+            custom_outro: None,
+            include_links: true,
+        }
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,6 @@
 // src/config/mod.rs
 pub mod filtering;
+pub mod html;
 pub mod input_source;
 pub mod listing;
 pub mod llm;
@@ -15,6 +16,7 @@ pub use tree_options::RustreeLibConfig;
 
 // Re-export specific enums for convenience in other modules
 pub use filtering::FilteringOptions;
+pub use html::HtmlOptions;
 pub use input_source::InputSourceOptions;
 pub use listing::ListingOptions;
 pub use llm::LlmOptions;

--- a/src/config/output_format.rs
+++ b/src/config/output_format.rs
@@ -8,4 +8,8 @@ pub enum OutputFormat {
 
     /// JSON array of NodeInfo structs (pretty-printed).
     Json,
+
+    /// HTML output wrapped in basic boilerplate, with the tree inside a <pre>
+    /// block. Mimics GNU tree's -H output (without hyperlinks for now).
+    Html,
 }

--- a/src/config/tree_options.rs
+++ b/src/config/tree_options.rs
@@ -1,6 +1,7 @@
 // src/config/tree_options.rs
 
 use crate::config::filtering::FilteringOptions;
+use crate::config::html::HtmlOptions;
 use crate::config::input_source::InputSourceOptions;
 use crate::config::listing::ListingOptions;
 use crate::config::metadata::MetadataOptions;
@@ -76,4 +77,7 @@ pub struct RustreeLibConfig {
 
     /// Miscellaneous configuration options
     pub misc: MiscOptions,
+
+    /// HTML output specific options (only used when `output-format`=html)
+    pub html: HtmlOptions,
 }

--- a/src/core/formatter/html.rs
+++ b/src/core/formatter/html.rs
@@ -1,0 +1,324 @@
+// src/core/formatter/html.rs
+//
+// Basic HTML formatter for RusTree.  It intentionally keeps the output nearly
+// identical to the plain-text tree produced by `TextTreeFormatter`, but wraps
+// it in minimal HTML so it can be viewed in a browser or embedded in other
+// documents.  Future enhancements (hyperlinks, CSS theming, collapsible
+// sections, etc.) can build on top of this foundation without affecting the
+// public interface of `TreeFormatter`.
+
+use super::base::TreeFormatter;
+use super::text_tree::TextTreeFormatter;
+
+use crate::config::RustreeLibConfig;
+use crate::config::html::HtmlOptions;
+use crate::core::error::RustreeError;
+use crate::core::tree::node::NodeInfo;
+
+/// Formatter producing an HTML page that contains the directory tree wrapped
+/// in a `<pre>` element.  Characters are HTML-escaped so the ASCII art is
+/// preserved.
+pub struct HtmlFormatter;
+
+impl TreeFormatter for HtmlFormatter {
+    fn format(
+        &self,
+        nodes: &[NodeInfo],
+        config: &RustreeLibConfig,
+    ) -> Result<String, RustreeError> {
+        let html_opts: &HtmlOptions = &config.html;
+
+        // 1. Obtain the lines produced by the text formatter so we can reuse
+        //    its indentation logic.  We will post-process each line to turn
+        //    the file name portion into a hyperlink (unless links are
+        //    disabled).
+        let plain_output = TextTreeFormatter.format(nodes, config)?;
+        let mut lines: Vec<String> = plain_output.lines().map(|s| s.to_string()).collect();
+
+        // Build a path representing the scan root (same technique as text formatter)
+        let scan_root_path_opt = nodes
+            .iter()
+            .find(|n| n.depth == 1)
+            .and_then(|n| n.path.parent().map(|p| p.to_path_buf()));
+
+        if html_opts.include_links {
+            for (idx, line) in lines.iter_mut().enumerate() {
+                // Skip the root line (idx == 0).  Nodes vector aligns with
+                // lines[1..]
+                if idx == 0 {
+                    continue;
+                }
+
+                if idx > nodes.len() {
+                    // Defensive: malformed line mapping (shouldn't happen but
+                    // occurs when the nodes vector is empty – e.g. test with
+                    // only root).
+                    continue;
+                }
+
+                let node = &nodes[idx - 1];
+
+                // Determine relative path for href
+                let mut rel_path = if let Some(scan_root) = &scan_root_path_opt {
+                    node.path
+                        .strip_prefix(scan_root)
+                        .unwrap_or(&node.path)
+                        .to_path_buf()
+                } else {
+                    node.path.clone()
+                };
+
+                if html_opts.strip_first_component {
+                    let _ = rel_path.iter().next(); // consumed
+                    rel_path = rel_path.iter().skip(1).collect::<std::path::PathBuf>();
+                }
+
+                // Build href string
+                let href = {
+                    let rel_str = rel_path.to_string_lossy().replace("\\", "/"); // Windows backslash → slash
+                    if let Some(prefix) = &html_opts.base_href {
+                        if prefix.ends_with('/') {
+                            format!("{}{}", prefix, rel_str)
+                        } else {
+                            format!("{}/{}", prefix, rel_str)
+                        }
+                    } else {
+                        rel_str
+                    }
+                };
+
+                // Determine visible label (same logic as text formatter)
+                let mut label = if config.listing.show_full_path {
+                    rel_path.to_string_lossy().to_string()
+                } else {
+                    node.name.clone()
+                };
+                if node.node_type == crate::core::tree::node::NodeType::Directory {
+                    label.push('/');
+                }
+
+                // HTML-escape label text
+                let escaped_label = html_escape(&label);
+
+                let anchor = format!("<a href=\"{}\">{}</a>", html_escape(&href), escaped_label);
+
+                // Replace last occurrence of the label in the line with the anchor.
+                if let Some(pos) = line.rfind(&label) {
+                    line.replace_range(pos..pos + label.len(), &anchor);
+                }
+            }
+        } else {
+            // No links → escape the entire lines (incl. names)
+            for line in &mut lines {
+                *line = html_escape(line);
+            }
+        }
+
+        // If links are included we have already escaped prefix parts except the
+        // anchor tag itself.  We need to ensure the *non-anchor* parts are
+        // escaped:
+        if html_opts.include_links {
+            for (idx, line) in lines.iter_mut().enumerate() {
+                // Skip root line? root line has no anchor maybe; escape fully.
+                if idx == 0 {
+                    *line = html_escape(line);
+                    continue;
+                }
+                // Split by anchor tag and escape outside parts
+                let mut result = String::new();
+                let mut remaining = line.as_str();
+                while let Some(start) = remaining.find("<a ") {
+                    let (before, rest) = remaining.split_at(start);
+                    result.push_str(&html_escape(before));
+                    if let Some(end) = rest.find("</a>") {
+                        let (anchor_part, tail) = rest.split_at(end + 4);
+                        result.push_str(anchor_part); // already safe
+                        remaining = tail;
+                    } else {
+                        // malformed, escape everything
+                        result.push_str(&html_escape(rest));
+                        remaining = "";
+                    }
+                }
+                result.push_str(&html_escape(remaining));
+                *line = result;
+            }
+        }
+
+        // Join lines with newline
+        let escaped_body = lines.join("\n");
+
+        // Build intro/outro — propagate I/O errors so users notice bad paths.
+        let intro = match &html_opts.custom_intro {
+            Some(path) => std::fs::read_to_string(path)?,
+            None => default_intro(config),
+        };
+
+        let outro = match &html_opts.custom_outro {
+            Some(path) => std::fs::read_to_string(path)?,
+            None => default_outro(),
+        };
+
+        let html_page = format!("{}<pre>{}</pre>{}", intro, escaped_body, outro);
+        Ok(html_page)
+    }
+}
+
+fn html_escape(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        match ch {
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '&' => out.push_str("&amp;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn default_intro(config: &RustreeLibConfig) -> String {
+    let raw_title = if !config.input_source.root_display_name.is_empty() {
+        &config.input_source.root_display_name
+    } else {
+        "Directory Tree"
+    };
+
+    let safe_title = html_escape(raw_title);
+
+    format!(
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <title>{safe_title}</title>\n  <style>body{{font-family:monospace;}}</style>\n</head>\n<body>\n"
+    )
+}
+
+fn default_outro() -> String {
+    "\n</body>\n</html>\n".to_string()
+}
+
+// --------------------------------------------------
+// Tests
+// --------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RustreeLibConfig;
+    use crate::core::tree::node::{NodeInfo, NodeType};
+    use std::path::PathBuf;
+
+    #[test]
+    fn basic_html_contains_expected_wrappers() {
+        let nodes = vec![NodeInfo {
+            path: PathBuf::from("root"),
+            name: "root".into(),
+            node_type: NodeType::Directory,
+            depth: 0,
+            size: None,
+            permissions: None,
+            mtime: None,
+            change_time: None,
+            create_time: None,
+            line_count: None,
+            word_count: None,
+            custom_function_output: None,
+        }];
+
+        let cfg = RustreeLibConfig::default();
+        let html = HtmlFormatter.format(&nodes, &cfg).unwrap();
+
+        // Basic sanity checks
+        assert!(html.starts_with("<!DOCTYPE html>"));
+        assert!(html.contains("<pre>"));
+        assert!(html.ends_with("</html>\n"));
+    }
+
+    #[test]
+    fn special_chars_are_escaped() {
+        let nodes = vec![NodeInfo {
+            path: PathBuf::from("root/file<1>&.txt"),
+            name: "file<1>&.txt".into(),
+            node_type: NodeType::File,
+            depth: 1,
+            size: None,
+            permissions: None,
+            mtime: None,
+            change_time: None,
+            create_time: None,
+            line_count: None,
+            word_count: None,
+            custom_function_output: None,
+        }];
+
+        let cfg = RustreeLibConfig::default();
+        let html = HtmlFormatter.format(&nodes, &cfg).unwrap();
+
+        // The raw characters should be escaped inside the pre block.
+        assert!(html.contains("&lt;1&gt;&amp;"));
+    }
+
+    #[test]
+    fn base_href_and_links_work() {
+        use crate::config::html::HtmlOptions;
+        use std::path::PathBuf;
+
+        let nodes = vec![NodeInfo {
+            path: PathBuf::from("root/sub/file.txt"),
+            name: "file.txt".into(),
+            node_type: NodeType::File,
+            depth: 2,
+            size: None,
+            permissions: None,
+            mtime: None,
+            change_time: None,
+            create_time: None,
+            line_count: None,
+            word_count: None,
+            custom_function_output: None,
+        }];
+
+        let cfg = RustreeLibConfig {
+            html: HtmlOptions {
+                base_href: Some("https://example.com".into()),
+                include_links: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let html = HtmlFormatter.format(&nodes, &cfg).unwrap();
+        assert!(html.contains("https://example.com/root/sub/file.txt"));
+    }
+
+    #[test]
+    fn no_links_flag_works() {
+        use std::path::PathBuf;
+
+        let nodes = vec![NodeInfo {
+            path: PathBuf::from("root/alpha.txt"),
+            name: "alpha.txt".into(),
+            node_type: NodeType::File,
+            depth: 1,
+            size: None,
+            permissions: None,
+            mtime: None,
+            change_time: None,
+            create_time: None,
+            line_count: None,
+            word_count: None,
+            custom_function_output: None,
+        }];
+
+        let cfg = RustreeLibConfig {
+            html: HtmlOptions {
+                include_links: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let html = HtmlFormatter.format(&nodes, &cfg).unwrap();
+        assert!(!html.contains("<a href="));
+        assert!(html.contains("alpha.txt"));
+    }
+}

--- a/src/core/formatter/mod.rs
+++ b/src/core/formatter/mod.rs
@@ -25,6 +25,7 @@
 //! ```
 
 pub mod base;
+pub mod html;
 pub mod json;
 pub mod markdown;
 pub mod text_tree;
@@ -34,6 +35,7 @@ pub use crate::config::output_format::OutputFormat;
 
 // Re-export the core types for external use
 pub use base::TreeFormatter;
+pub use html::HtmlFormatter;
 pub use json::JsonFormatter;
 pub use markdown::MarkdownFormatter;
 pub use text_tree::TextTreeFormatter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,7 @@ pub fn format_nodes(
         LibOutputFormat::Text => Box::new(TextTreeFormatter),
         LibOutputFormat::Markdown => Box::new(MarkdownFormatter),
         LibOutputFormat::Json => Box::new(core::formatter::JsonFormatter),
+        LibOutputFormat::Html => Box::new(core::formatter::HtmlFormatter),
     };
     let tree_output = formatter_instance.format(nodes, config)?;
 

--- a/tests/text_formatter_tests.rs
+++ b/tests/text_formatter_tests.rs
@@ -150,6 +150,7 @@ fn test_formatter_summary_line_correct_for_dirs_only_mode() -> Result<()> {
             metadata: config.metadata.clone(),
             filtering: config.filtering.clone(),
             misc: config.misc.clone(),
+            html: Default::default(),
         },
     )?;
 
@@ -236,6 +237,7 @@ fn test_formatter_no_file_specific_metadata_prefixes_in_dirs_only_mode() -> Resu
             input_source: config.input_source.clone(),
             filtering: config.filtering.clone(),
             misc: config.misc.clone(),
+            html: Default::default(),
         },
     )?;
     let mut dir_nodes_only: Vec<NodeInfo> = original_nodes_for_filtering


### PR DESCRIPTION
This PR introduces support for generating HTML output format, allowing users to create structured HTML documents with tree representations.

## What this PR does:
- Adds the ability to specify HTML as an output format via the command line.
- Includes new command-line flags for HTML-specific configurations such as base URL, intro and outro files, and link generation.

## Why these changes were made:
- To enhance the output capabilities of the tool, enabling users to easily integrate directory trees into web pages and other HTML documents.

## Key changes made:
- Introduced a new `HtmlOutputArgs` struct to handle HTML-specific CLI arguments.
- Created a `HtmlFormatter` that formats directory trees into HTML, preserving ASCII art within `<pre>` tags.
- Updated documentation to reflect the new output options and provide examples for usage.

## Testing notes:
- Added tests to verify HTML formatting including link generation and escaping of special characters.
- Ensured that HTML output behaves correctly with various CLI options. 

## Notes:
- The default HTML output is minimal and can be customized with user-defined intro and outro HTML fragments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for HTML output format, enabling directory trees to be exported as self-contained HTML pages with customizable hyperlinks.
  - Introduced CLI options for HTML output customization, including base URL for links, stripping the first path component, disabling links, and specifying custom HTML intro/outro sections.

- **Documentation**
  - Expanded documentation to include new HTML and JSON output formats and detailed configuration options.
  - Added usage examples and tables mapping HTML flags to GNU tree equivalents.

- **Tests**
  - Updated tests to initialize HTML configuration with default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->